### PR TITLE
feat: add GetInputsParser method

### DIFF
--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -233,7 +233,29 @@ func GetParser(ABI *core.SmartContract_ABI, method string) (eABI.Arguments, erro
 			for _, out := range entry.Outputs {
 				ty, err := eABI.NewType(out.Type, "", nil)
 				if err != nil {
-					return nil, fmt.Errorf("invalid parem %s: %+v", out.Type, err)
+					return nil, fmt.Errorf("invalid param %s: %+v", out.Type, err)
+				}
+				arguments = append(arguments, eABI.Argument{
+					Name:    out.Name,
+					Type:    ty,
+					Indexed: out.Indexed,
+				})
+			}
+			return arguments, nil
+		}
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+// GetInputsParser returns input method parser arguments from ABI
+func GetInputsParser(ABI *core.SmartContract_ABI, method string) (eABI.Arguments, error) {
+	arguments := eABI.Arguments{}
+	for _, entry := range ABI.Entrys {
+		if entry.Name == method {
+			for _, out := range entry.Inputs {
+				ty, err := eABI.NewType(out.Type, "", nil)
+				if err != nil {
+					return nil, fmt.Errorf("invalid param %s: %+v", out.Type, err)
 				}
 				arguments = append(arguments, eABI.Argument{
 					Name:    out.Name,


### PR DESCRIPTION
This method can be used to parse `TriggerSmartContract` data parameters by gettin transaction by id.