### PR TITLE
abi padded bug

### DIFF
--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -132,17 +132,21 @@ func GetPaddedParam(param []Param) ([]byte, error) {
 				if (ty.Elem.T == eABI.IntTy || ty.Elem.T == eABI.UintTy) &&
 					ty.Elem.Size > 64 {
 					tmp := make([]*big.Int, 0)
-					tmpSlice, ok := v.([]string)
+					tmpSlice, ok := v.([]interface{})
 					if !ok {
 						return nil, fmt.Errorf("unable to convert array of unints %+v", p)
 					}
 					for i := range tmpSlice {
 						var value *big.Int
 						// check for hex char
-						if strings.HasPrefix(tmpSlice[i], "0x") {
-							value, _ = new(big.Int).SetString(tmpSlice[i][2:], 16)
+						item, ok := tmpSlice[i].(string)
+						if !ok {
+							return nil, fmt.Errorf("unable to convert array of unints %+v", p)
+						}
+						if strings.HasPrefix(item, "0x") {
+							value, _ = new(big.Int).SetString(item[2:], 16)
 						} else {
-							value, _ = new(big.Int).SetString(tmpSlice[i], 10)
+							value, _ = new(big.Int).SetString(item, 10)
 						}
 						tmp = append(tmp, value)
 					}


### PR DESCRIPTION
`tx, e := TronClient.TriggerContract(
  config.TronAddressString,
  contractAddress,
  "deploy(uint256[])",
  "[{\"uint256[]\":["0x8157de19c158b16582821e315285b4dc"]}]",
  300000000, 0, "", 0, // todo
  )`
when i use this code build tx, raise some error (unable to convert array of unints map["uint256[]": [0x8157de19c158b16582821e315285b4dc]]). i test file abi.go, the var tmpSlice is []interface{}, not []string