### PR TITLE
add tronsdk_compat build tag to allow disabling cgo

### DIFF
--- a/pkg/keystore/recover.go
+++ b/pkg/keystore/recover.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !tronsdk_compat
+// +build !windows,!tronsdk_compat
 
 package keystore
 

--- a/pkg/keystore/recover_compat.go
+++ b/pkg/keystore/recover_compat.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows || tronsdk_compat
+// +build windows tronsdk_compat
 
 package keystore
 


### PR DESCRIPTION
I'd like to add a gotron-sdk specific build tag to disable inclusion of C cores (go-ethereum's secp256k1 is not compatible with being statically linked).

We'd like to depend on gotron-sdk but not sacrifice portability. Please consider including.