### PR TITLE
 Make Config Directory Creation Explicit

### DIFF
--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -126,6 +126,8 @@ func ImportKeyStore(keyPath, name, passphrase string) (string, error) {
 	if hasAddress {
 		return "", fmt.Errorf("address %s already exists in keystore", key.Address.String())
 	}
+	// create home dir if it doesn't exist
+	store.InitConfigDir()
 	uDir, _ := homedir.Dir()
 	newPath := filepath.Join(uDir, common.DefaultConfigDirName, common.DefaultConfigAccountAliasesDirName, name, filepath.Base(keyPath))
 	err = writeToFile(newPath, string(keyJSON))

--- a/pkg/store/local.go
+++ b/pkg/store/local.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func init() {
+func InitConfigDir() {
 	uDir, _ := homedir.Dir()
 	tronCTLDir := path.Join(uDir, c.DefaultConfigDirName, c.DefaultConfigAccountAliasesDirName)
 	if _, err := os.Stat(tronCTLDir); os.IsNotExist(err) {


### PR DESCRIPTION
## Description

This PR addresses an issue where the library attempts to create a directory on the local file system during initialization via the `init()` function. This causes errors in environments with a read-only file system.

The change replaces the `init()` function with an explicitly callable `InitConfigDir()` function. This gives consumers control over when (or whether) the directory is created. The `InitConfigDir()` is now only called where necessary (e.g., within `ImportKeyStore`), avoiding unintended side effects in read-only environments.

Fixes #147 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Ticket

TRON-147

## How Has This Been Tested?

- [x] Manual tests (ran in both read-only and normal FS environments)
- [ ] Unit tests (existing logic reused; no new tests)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
