### PR TITLE
fix: remove duplicate error checking in UpdateAccountPermission

### DIFF
--- a/pkg/client/account.go
+++ b/pkg/client/account.go
@@ -449,9 +449,6 @@ func (g *GrpcClient) UpdateAccountPermission(from string, owner, witness map[str
 		if err != nil {
 			return nil, err
 		}
-		if err != nil {
-			return nil, err
-		}
 		contract.Witness = witnessPermission
 	}
 


### PR DESCRIPTION
Remove redundant error checking block in pkg/client/account.go that was duplicated at lines 452-454.

Fixes #160

## Description

<!-- Please include a summary of the changes and which issue is fixed. -->
<!-- Also include relevant motivation and context. -->

Fixes # (issue)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Performance improvement

## Ticket

TRON-160

## How Has This Been Tested?

No need, just duplicated code.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
