### PR TITLE
fix: normalize secp256k1 curve for non-CGO builds

### DIFF
--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -48,7 +48,12 @@ func TestSend(t *testing.T) {
 	// btcec.PrivKeyFromBytes only returns a secret key and public key
 	sk, _ := btcec.PrivKeyFromBytes(privateKeyBytes)
 
-	signature, err := crypto.Sign(hash, sk.ToECDSA())
+	// Convert btcec key to go-ethereum's curve to ensure compatibility
+	// with non-CGO builds (e.g., Windows)
+	ecdsaKey, err := crypto.ToECDSA(crypto.FromECDSA(sk.ToECDSA()))
+	require.Nil(t, err)
+
+	signature, err := crypto.Sign(hash, ecdsaKey)
 	require.Nil(t, err)
 	tx.Transaction.Signature = append(tx.Transaction.Signature, signature)
 

--- a/pkg/client/transaction/signer.go
+++ b/pkg/client/transaction/signer.go
@@ -22,6 +22,14 @@ func SignTransaction(tx *core.Transaction, signer *btcec.PrivateKey) (*core.Tran
 }
 
 func SignTransactionECDSA(tx *core.Transaction, signer *ecdsa.PrivateKey) (*core.Transaction, error) {
+	// Ensure the private key uses go-ethereum's secp256k1 curve.
+	// Keys from btcec.ToECDSA() use a different curve instance that fails
+	// validation in go-ethereum's non-CGO Sign() (e.g., on Windows).
+	signer, err := crypto.ToECDSA(crypto.FromECDSA(signer))
+	if err != nil {
+		return nil, err
+	}
+
 	rawData, err := proto.Marshal(tx.GetRawData())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Fixes `SignTransactionECDSA` failing with "private key curve is not secp256k1" on non-CGO builds (Windows, `CGO_ENABLED=0`)
- Root cause: `btcec.PrivateKey.ToECDSA()` sets the curve to btcec's secp256k1 instance, but go-ethereum's non-CGO `crypto.Sign()` requires its own `S256()` curve instance (pointer comparison at `signature_nocgo.go:82`)
- Fix normalizes the key via `crypto.FromECDSA`/`crypto.ToECDSA` round-trip, which preserves the key material and only changes the curve pointer. No-op for keys already using go-ethereum's curve (e.g., keystore path)

## Breaking changes

None. Both btcec's and go-ethereum's secp256k1 curves are mathematically identical — same parameters, same operations, same signatures. The issue is purely a Go-level pointer comparison in go-ethereum's non-CGO `crypto.Sign()` validation (`signature_nocgo.go:82`), not a cryptographic difference. The fix only changes which Go object represents the curve, not the key material or signature output. Existing code on Linux/macOS (CGO enabled) will produce byte-for-byte identical results.

## Test plan

- [ ] Verify existing tests pass on macOS/Linux (CGO enabled)
- [ ] Verify signing works on Windows (CGO disabled) with btcec-derived keys
- [ ] Verify keystore-based signing is unaffected

Closes #173