### PR TITLE
feat: add GetReceivedDelegatedResourcesV2 for incoming delegations

### DIFF
--- a/pkg/client/account_test.go
+++ b/pkg/client/account_test.go
@@ -115,6 +115,20 @@ func TestDelegateMaxSize(t *testing.T) {
 	require.GreaterOrEqual(t, tx.GetMaxSize(), int64(0))
 }
 
+func TestGetDelegatedResourcesV2(t *testing.T) {
+	resources, err := conn.GetDelegatedResourcesV2(accountAddress)
+	require.Nil(t, err)
+	require.NotNil(t, resources)
+	require.Greater(t, len(resources), 0)
+}
+
+func TestGetReceivedDelegatedResourcesV2(t *testing.T) {
+	resources, err := conn.GetReceivedDelegatedResourcesV2(accountAddressWitness)
+	require.Nil(t, err)
+	require.NotNil(t, resources)
+	require.Greater(t, len(resources), 0)
+}
+
 func TestUnfreezeLeftCount(t *testing.T) {
 	t.Skip() // Only in testnet nile
 	tx, err := conn.GetAvailableUnfreezeCount(testnetNileAddressExample)


### PR DESCRIPTION
## Summary

- Adds `GetReceivedDelegatedResourcesV2()` to query resources delegated **to** an account by other accounts (Stake 2.0)
- Uses the `FromAccounts` field from `GetDelegatedResourceAccountIndexV2` which was previously unused in the SDK
- Mirrors the existing `GetDelegatedResourcesV2()` (outgoing) but for the incoming direction
- Adds tests using known Nile testnet accounts with active delegations

## Note

The gRPC API returns only **currently active** delegations. Historical/reclaimed delegations (visible on Tronscan) are not available through the node's gRPC interface.

## Test plan

- [x] `TestGetDelegatedResourcesV2` — verifies outgoing delegations for `accountAddress`
- [x] `TestGetReceivedDelegatedResourcesV2` — verifies incoming delegations for `accountAddressWitness`
- [x] Both tests pass against Nile testnet

Closes #171