### PR TITLE
fix(abi): support uint256[] and int arrays from JSON input

### DIFF
--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -66,6 +66,23 @@ func TestABIParamArrayBytes(t *testing.T) {
 	assert.Equal(t, "0001020001020001020001020001020001020001020001020001020001020001", hex.EncodeToString(b))
 }
 
+func TestABIParamArrayUint256FromJSON(t *testing.T) {
+	// Issue #120: uint256[] loaded via LoadFromJSON produces []interface{}, not []string
+	param, err := LoadFromJSON(`[{"uint256[]": ["100", "200"]}]`)
+	require.NoError(t, err)
+	b, err := GetPaddedParam(param)
+	require.NoError(t, err)
+	// offset(32) + length(32) + 2 elements(64) = 128
+	assert.Len(t, b, 128, fmt.Sprintf("Wrong length %d/%d", len(b), 128))
+}
+
+func TestABIParamSliceUint256(t *testing.T) {
+	// Dynamic-length uint256[] with []string input
+	b, err := GetPaddedParam([]Param{{"uint256[]": []string{"100", "200"}}})
+	require.NoError(t, err)
+	assert.Len(t, b, 128, fmt.Sprintf("Wrong length %d/%d", len(b), 128))
+}
+
 func TestABI_HEXuint256(t *testing.T) {
 	b, err := GetPaddedParam([]Param{
 		{"uint256": "43981"},


### PR DESCRIPTION
## Summary

- Fix type assertion failure when `uint256[]` is loaded via `LoadFromJSON` — JSON unmarshaling produces `[]interface{}` but `GetPaddedParam` only accepted `[]string`
- Add `toStringSlice()` helper to accept both `[]string` and `[]interface{}` inputs
- Add `convertSmallIntSlice()` to handle int/uint arrays with size <= 64 (previously unsupported)
- Fix typo in error message ("unints" -> "ints")

Closes #120

## Test plan

- [x] `TestABIParamArrayUint256FromJSON` — `uint256[]` via `LoadFromJSON` (the reported bug)
- [x] `TestABIParamSliceUint256` — `uint256[]` with `[]string` input (existing path)
- [x] `TestABIParamArrayUint256` — fixed-size `uint256[2]` still works
- [x] All existing tests pass