### PR TITLE
fix(abi): add bytes[] support in GetPaddedParam

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,7 @@ tone_instructions: >
   Be concise and direct. Focus on correctness, security, and Go idioms.
 reviews:
   profile: chill
-  request_changes_workflow: false
+  request_changes_workflow: true
   high_level_summary: true
   sequence_diagrams: true
   collapse_walkthrough: true

--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -148,6 +148,22 @@ func GetPaddedParam(param []Param) ([]byte, error) {
 						v = convertSmallIntSlice(*ty.Elem, strs)
 					}
 				}
+
+				if ty.Elem.T == eABI.BytesTy {
+					tmp, ok := v.([]interface{})
+					if !ok {
+						return nil, fmt.Errorf("unable to convert array of bytes %+v", p)
+					}
+					result := make([][]byte, len(tmp))
+					for i := range tmp {
+						b, err := convertToBytes(*ty.Elem, tmp[i])
+						if err != nil {
+							return nil, err
+						}
+						result[i] = b.([]byte)
+					}
+					v = result
+				}
 			}
 			if ty.T == eABI.AddressTy {
 				if v, err = convetToAddress(v); err != nil {

--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -85,6 +85,26 @@ func TestABIParamSliceUint256(t *testing.T) {
 	assert.Len(t, b, 128, fmt.Sprintf("Wrong length %d/%d", len(b), 128))
 }
 
+func TestABIParamArrayUint256HexFromJSON_PR95(t *testing.T) {
+	// PR #95: hex uint256[] via JSON triggers same []interface{} issue as #120
+	param, err := LoadFromJSON(`[{"uint256[]":["0x8157de19c158b16582821e315285b4dc"]}]`)
+	require.NoError(t, err)
+	b, err := GetPaddedParam(param)
+	require.NoError(t, err)
+	assert.Greater(t, len(b), 0, "encoded hex uint256[] should not be empty")
+}
+
+func TestABIParamArrayBytesSlice(t *testing.T) {
+	// Issue #131: bytes[] (array of dynamic bytes)
+	param, err := LoadFromJSON(`[{"bytes[]": ["deadbeef", "cafebabe"]}]`)
+	require.NoError(t, err)
+	b, err := GetPaddedParam(param)
+	require.NoError(t, err)
+	// offset(32) + length(32) + 2 element offsets(64) + 2 elements (len+data each, padded)
+	// = 32 + 32 + 64 + (32+32) + (32+32) = 256
+	assert.Len(t, b, 256, "unexpected encoded length for bytes[]")
+}
+
 func TestABI_HEXuint256(t *testing.T) {
 	b, err := GetPaddedParam([]Param{
 		{"uint256": "43981"},


### PR DESCRIPTION
## Summary

- Add handling for `bytes[]` (dynamic byte arrays) in `GetPaddedParam`
- The `SliceTy` handler had no case for `BytesTy` elements, causing `bytes[]` parameters to pass through without proper encoding
- Each element is now converted via the existing `convertToBytes` and packed as `[][]byte`
- Enable `request_changes_workflow` in CodeRabbit config

Closes #131

## Test plan

- [x] `TestABIParamArrayBytesSlice` — encodes `bytes[]` from JSON input
- [x] `TestABIParamArrayUint256HexFromJSON_PR95` — validates hex `uint256[]` from PR #95 scenario
- [x] `TestABIParamArrayBytes` — existing `bytes32` test still passes
- [x] All existing tests pass

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of byte arrays within parameters, supporting proper conversion and processing of array-of-bytes data structures.
  * Enhanced JSON parsing for array parameters, addressing issues with uint256 and bytes array deserialization.

* **Tests**
  * Added test coverage for byte array parameters and hex-encoded uint256 arrays from JSON input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->