### PR TITLE
fix(decimals): handle negative exponents in Pow function

### DIFF
--- a/pkg/common/decimals/decimals.go
+++ b/pkg/common/decimals/decimals.go
@@ -1,9 +1,15 @@
 package decimals
 
-import "math/big"
+import (
+	"math"
+	"math/big"
+)
 
 func Pow(a *big.Float, e int64) *big.Float {
 	if e < 0 {
+		if e == math.MinInt64 {
+			return Div(NewFloat(1), Mul(a, Pow(a, -(e+1))))
+		}
 		return Div(NewFloat(1), Pow(a, -e))
 	}
 	result := NewFloat(1)

--- a/pkg/common/decimals/decimals_test.go
+++ b/pkg/common/decimals/decimals_test.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"math/big"
 	"testing"
+	"time"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/common/decimals"
 	"github.com/stretchr/testify/assert"
@@ -267,6 +268,33 @@ func TestPow_NegativeExponent(t *testing.T) {
 			gotF, _ := got.Float64()
 			assert.InDelta(t, tt.want, gotF, math.Abs(tt.want)*1e-10+1e-15)
 		})
+	}
+}
+
+func TestPow_MinInt64DoesNotStackOverflow(t *testing.T) {
+	// math.MinInt64 negation overflows in int64; verify the guard prevents
+	// infinite recursion by running in a goroutine with a short deadline.
+	// We cannot wait for the full result (the O(n) loop is impractical for
+	// MaxInt64 iterations), but we can confirm it does not immediately
+	// stack-overflow or panic.
+	done := make(chan struct{})
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Pow(2, MinInt64) panicked: %v", r)
+			}
+			close(done)
+		}()
+		// This will enter the MinInt64 guard branch and then start the
+		// long loop — we just need it to survive past the guard.
+		_ = decimals.Pow(bf(2), math.MinInt64)
+	}()
+	// Give it a brief moment; if it stack-overflows it will panic instantly.
+	select {
+	case <-done:
+		// Returned or panicked — both handled above.
+	case <-time.After(100 * time.Millisecond):
+		// Still running the long loop — means the guard worked, no stack overflow.
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Pow(a, e)` silently returned `1` for negative exponents because `for range e` iterates zero times when `e < 0`
- Now detects negative exponents and computes the reciprocal `1/a^|e|`, matching the approach already used in `numeric.Pow`
- Added 7 test cases covering negative exponent scenarios

Closes #185

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The power function now supports negative exponents, calculating results by taking the reciprocal of the positive exponent calculation. This enables accurate fractional power computations for mathematical operations.

* **Tests**
  * Added comprehensive test coverage for negative exponent functionality, validating correctness across various base values and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->