### PR TITLE
feat(transaction): add marshal/unmarshal for hex and JSON formats

### DIFF
--- a/pkg/client/transaction/marshal.go
+++ b/pkg/client/transaction/marshal.go
@@ -34,7 +34,7 @@ type jsonTransaction struct {
 	TxID       string          `json:"txID"`
 	RawData    json.RawMessage `json:"raw_data,omitempty"`
 	RawDataHex string          `json:"raw_data_hex"`
-	Signature  []string        `json:"signature"`
+	Signature  []string        `json:"signature,omitempty"`
 }
 
 // FromRawDataHex reconstructs a Transaction from a hex-encoded raw_data

--- a/pkg/client/transaction/marshal_test.go
+++ b/pkg/client/transaction/marshal_test.go
@@ -115,11 +115,14 @@ func TestFromRawDataHex_InvalidHex(t *testing.T) {
 }
 
 func TestFromRawDataHex_InvalidProtobuf(t *testing.T) {
-	// Valid hex but not valid protobuf for TransactionRaw —
-	// proto.Unmarshal is lenient with unknown fields, so we just verify it doesn't panic.
+	// Valid hex but invalid wire-format protobuf data.
 	_, err := FromRawDataHex("deadbeef")
-	// This may or may not error depending on protobuf parsing; just ensure no panic.
-	_ = err
+	if err == nil {
+		t.Fatal("expected error for invalid protobuf data")
+	}
+	if !strings.Contains(err.Error(), "unmarshal") {
+		t.Errorf("expected unmarshal error, got: %v", err)
+	}
 }
 
 func TestToRawDataHex(t *testing.T) {
@@ -258,8 +261,9 @@ func TestToJSON_NoSignatures(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 
-	if jtx.Signature != nil {
-		t.Errorf("expected nil signatures, got %v", jtx.Signature)
+	// With omitempty, the signature field should be absent from JSON output
+	if strings.Contains(string(jsonBytes), `"signature"`) {
+		t.Error("expected signature field to be omitted from JSON output")
 	}
 }
 
@@ -315,7 +319,9 @@ func TestFromJSON_TxIDMismatch(t *testing.T) {
 
 	// Tamper with the txID
 	var jtx map[string]any
-	json.Unmarshal(jsonBytes, &jtx)
+	if err := json.Unmarshal(jsonBytes, &jtx); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
 	jtx["txID"] = "0000000000000000000000000000000000000000000000000000000000000000"
 	tampered, _ := json.Marshal(jtx)
 


### PR DESCRIPTION
## Summary

- Add `FromRawDataHex` / `ToRawDataHex` for hex-encoded protobuf serialization
- Add `FromJSON` / `ToJSON` for TRON HTTP API JSON format compatibility
- Include txID validation (SHA256 of raw_data) when present in JSON input
- 23 unit tests including fixtures from real Nile testnet API responses

Closes #193

## Test plan

- [x] Unit tests pass (`go test ./pkg/client/transaction/...` — 33 total, 23 new)
- [x] Round-trip tests: `tx → ToRawDataHex → FromRawDataHex` and `tx → ToJSON → FromJSON`
- [x] Real API fixtures: verified against Nile testnet `gettransactionbyid` and `createtransaction` responses
- [x] txID computation matches TRON API for both signed and unsigned transactions
- [x] Re-encoded `raw_data_hex` is byte-identical to API output
- [x] Error cases: invalid hex, invalid JSON, missing fields, txID mismatch, bad signature hex
- [x] Full project builds cleanly (`go build ./...`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON and hex import/export for TRON-style transactions, with signature support and automatic TXID generation/validation; clearer error responses for common conversion/validation failures.

* **Tests**
  * Comprehensive tests for hex/JSON round-trips, signature encoding/decoding, TXID checks, error scenarios, and real-world transaction fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->