### PR TITLE
docs: improve README and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,7 +72,7 @@ make tidy
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/):
 
-```
+```text
 <type>(<scope>): <description>
 
 [optional body]
@@ -81,7 +81,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 **Types:** `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `ci`, `perf`
 
 **Examples:**
-```
+```text
 feat(client): add GetAccountResource method
 fix(address): handle empty base58 input
 docs: update SDK usage examples

--- a/README.md
+++ b/README.md
@@ -18,16 +18,21 @@ GoTRON SDK is a comprehensive Go SDK and CLI tool for interacting with the TRON 
 
 GoTRON SDK is built for **backend and infrastructure** teams that need performance, reliability, and operational tooling.
 
-| | GoTRON SDK | tronweb (JS/TS) | tron-api-python |
+| | GoTRON SDK | [tronweb] (JS/TS) | [tron-api-python] |
 |--|-----------|-----------------|-----------------|
 | **Transport** | gRPC (binary, streaming) | HTTP/JSON | HTTP/JSON |
 | **Deployment** | Single static binary | Node.js runtime | Python runtime |
 | **Hardware Signing** | Built-in Ledger support | Separate adapter | No |
-| **CLI Tooling** | `tronctl` included | None | None |
+| **CLI Tooling** | `tronctl` included | None | Yes (CLI framework) |
 | **Concurrency** | Goroutines (native) | Event loop | GIL-limited |
 | **HD Wallets** | Yes (BIP39/44) | Yes (BIP39/44) | No |
-| **Multi-sig** | Yes | Yes | Limited |
-| **Type Safety** | Full (compiled) | Full (TypeScript) | Hints only |
+| **Multi-sig** | Yes | Yes | Not documented |
+| **Type Safety** | Full (compiled) | Full (TypeScript) | Not documented |
+
+> Comparison as of 2026-03-16. Verify claims against each project's README.
+
+[tronweb]: https://github.com/tronprotocol/tronweb
+[tron-api-python]: https://github.com/iexbase/tron-api-python
 
 ## Features
 
@@ -196,7 +201,7 @@ source <(tronctl completion zsh)
 ## Development
 
 ### Requirements
-- Go 1.18 or higher
+- Go 1.24 or higher
 - Make (for building)
 - Protocol Buffers compiler (for regenerating protos)
 


### PR DESCRIPTION
## Summary
- Fix license text from MIT to LGPL-3.0 to match the actual LICENSE file
- Add "Built For" and "Why GoTRON?" sections to better position the SDK for target audiences (exchanges, wallets, trading bots, staking services, infrastructure)
- Add verified comparison table against tronweb and tron-api-python (checked against actual repos)
- Simplify SDK quickstart example for faster onboarding
- Add "Projects Using GoTRON" section with link to submit projects
- Create CONTRIBUTING.md referenced by README but previously missing

## Test plan
- [x] Verify README renders correctly on GitHub
- [x] Verify CONTRIBUTING.md renders correctly on GitHub
- [x] Verify all links resolve (LICENSE, issue tracker, labels)
- [x] Confirm comparison table claims are accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contribution guidelines covering setup and PR process.
  * Enhanced README with clearer quickstart, feature comparison, and a projects showcase.
  * Updated quickstart sample for simpler address usage and clearer balance output (includes currency).
  * Updated license to LGPL-3.0 and raised required Go version to 1.24+.

* **Chores**
  * Reorganized and improved documentation structure and flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->