### PR TITLE
Add non-positive amount validation to FreezeBalanceV2/UnfreezeBalanceV2

### DIFF
--- a/pkg/client/bank.go
+++ b/pkg/client/bank.go
@@ -49,6 +49,10 @@ func (g *GrpcClient) FreezeBalance(from, delegateTo string,
 // FreezeBalanceV2 freezes balance from base58 address.
 func (g *GrpcClient) FreezeBalanceV2(from string,
 	resource core.ResourceCode, frozenBalance int64) (*api.TransactionExtention, error) {
+	if frozenBalance <= 0 {
+		return nil, fmt.Errorf("freeze balance must be positive, got %d", frozenBalance)
+	}
+
 	var err error
 
 	contract := &core.FreezeBalanceV2Contract{}
@@ -110,6 +114,10 @@ func (g *GrpcClient) UnfreezeBalance(from, delegateTo string, resource core.Reso
 
 // UnfreezeBalanceV2 unfreezes balance from base58 address.
 func (g *GrpcClient) UnfreezeBalanceV2(from string, resource core.ResourceCode, unfreezeBalance int64) (*api.TransactionExtention, error) {
+	if unfreezeBalance <= 0 {
+		return nil, fmt.Errorf("unfreeze balance must be positive, got %d", unfreezeBalance)
+	}
+
 	var err error
 
 	contract := &core.UnfreezeBalanceV2Contract{}

--- a/pkg/client/bank_test.go
+++ b/pkg/client/bank_test.go
@@ -1,0 +1,37 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFreezeBalanceV2_ZeroAmount(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+	_, err := c.FreezeBalanceV2(accountAddress, core.ResourceCode_BANDWIDTH, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "freeze balance must be positive")
+}
+
+func TestFreezeBalanceV2_NegativeAmount(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+	_, err := c.FreezeBalanceV2(accountAddress, core.ResourceCode_BANDWIDTH, -100)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "freeze balance must be positive")
+}
+
+func TestUnfreezeBalanceV2_ZeroAmount(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+	_, err := c.UnfreezeBalanceV2(accountAddress, core.ResourceCode_ENERGY, 0)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unfreeze balance must be positive")
+}
+
+func TestUnfreezeBalanceV2_NegativeAmount(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+	_, err := c.UnfreezeBalanceV2(accountAddress, core.ResourceCode_ENERGY, -500)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unfreeze balance must be positive")
+}


### PR DESCRIPTION
## Summary

- Add local `<= 0` validation to `FreezeBalanceV2` and `UnfreezeBalanceV2` in `pkg/client/bank.go`
- Return clear error messages instead of relying on server-side validation
- Add unit tests covering zero and negative amounts for both functions

Closes #200

## Test plan

- [x] `TestFreezeBalanceV2_ZeroAmount` — verifies zero amount is rejected
- [x] `TestFreezeBalanceV2_NegativeAmount` — verifies negative amount is rejected
- [x] `TestUnfreezeBalanceV2_ZeroAmount` — verifies zero amount is rejected
- [x] `TestUnfreezeBalanceV2_NegativeAmount` — verifies negative amount is rejected
- [x] Existing `TestFreezeV2` and `TestUnfreezeV2` still pass
- [x] Full test suite passes with `make test`
- [x] `make lint` reports 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation for balance freeze and unfreeze operations to reject zero and negative amounts.
  * Users now receive clear error messages when attempting operations with invalid amounts.

* **Tests**
  * Added comprehensive unit tests to ensure invalid balance amounts are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->