### PR TITLE
fix(trc20): validate owner parameter in TRC20TransferFrom

### DIFF
--- a/pkg/client/trc20.go
+++ b/pkg/client/trc20.go
@@ -181,6 +181,9 @@ func (g *GrpcClient) TRC20Send(from, to, contract string, amount *big.Int, feeLi
 
 // TRC20TransferFrom transfers tokens on behalf of another address (owner signs the tx).
 func (g *GrpcClient) TRC20TransferFrom(owner, from, to, contract string, amount *big.Int, feeLimit int64) (*api.TransactionExtention, error) {
+	if _, err := address.Base58ToAddress(owner); err != nil {
+		return nil, fmt.Errorf("invalid owner address: %w", err)
+	}
 	addrA, err := address.Base58ToAddress(from)
 	if err != nil {
 		return nil, err

--- a/pkg/client/trc20_test.go
+++ b/pkg/client/trc20_test.go
@@ -198,6 +198,22 @@ func TestTRC20TransferFrom(t *testing.T) {
 	require.NotNil(t, tx)
 }
 
+func TestTRC20TransferFrom_InvalidOwner(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+
+	t.Run("empty owner", func(t *testing.T) {
+		_, err := c.TRC20TransferFrom("", "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH", "TUoHaVjx7n5xz8LwPRDckgFrDWhMhuSuJM", "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", big.NewInt(1), 100)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid owner address")
+	})
+
+	t.Run("invalid owner", func(t *testing.T) {
+		_, err := c.TRC20TransferFrom("not-valid", "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH", "TUoHaVjx7n5xz8LwPRDckgFrDWhMhuSuJM", "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t", big.NewInt(1), 100)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid owner address")
+	})
+}
+
 func TestTRC20Call_RPCError(t *testing.T) {
 	mock := &mockWalletServer{
 		TriggerConstantContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {


### PR DESCRIPTION
## Summary

- Add input validation for the `owner` parameter in `TRC20TransferFrom` by calling `address.Base58ToAddress(owner)` at the start of the function, returning a descriptive error if empty or invalid
- Add test `TestTRC20TransferFrom_InvalidOwner` covering empty and invalid owner inputs

Closes #199

## Test plan

- [x] `TestTRC20TransferFrom_InvalidOwner/empty_owner` — verifies empty owner returns error
- [x] `TestTRC20TransferFrom_InvalidOwner/invalid_owner` — verifies invalid owner returns error
- [x] `TestTRC20TransferFrom` — existing happy path still passes
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address validation in token transfers. The system now validates owner addresses upfront before processing transfer requests. Invalid or empty addresses are immediately rejected with clear, descriptive error messages instead of failing downstream, providing better error feedback and preventing malformed requests from being submitted to the network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->