### PR TITLE
feat(client): return typed error from EstimateEnergy when node unsupported

### DIFF
--- a/pkg/client/contracts.go
+++ b/pkg/client/contracts.go
@@ -9,6 +9,8 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // UpdateEnergyLimitContract update contract enery limit
@@ -231,6 +233,9 @@ func (g *GrpcClient) estimateEnergy(ct *core.TriggerSmartContract) (*api.Estimat
 
 	tx, err := g.Client.EstimateEnergy(ctx, ct)
 	if err != nil {
+		if s, ok := status.FromError(err); ok && s.Code() == codes.Unimplemented {
+			return nil, fmt.Errorf("%w: %w", ErrEstimateEnergyNotSupported, err)
+		}
 		return nil, err
 	}
 

--- a/pkg/client/contracts_integration_test.go
+++ b/pkg/client/contracts_integration_test.go
@@ -3,10 +3,16 @@
 package client_test
 
 import (
+	"errors"
+	"os"
 	"testing"
+	"time"
 
+	"github.com/fbsobreira/gotron-sdk/pkg/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestIntegration_GetContractABI(t *testing.T) {
@@ -91,6 +97,29 @@ func TestIntegration_EstimateEnergy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, result)
 	assert.Greater(t, result.GetEnergyRequired(), int64(0), "energy estimate should be positive")
+}
+
+func TestIntegration_EstimateEnergyNotSupported(t *testing.T) {
+	endpoint := os.Getenv("TRON_UNSUPPORTED_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("TRON_UNSUPPORTED_ENDPOINT not set — skipping unsupported-node test")
+	}
+
+	c := client.NewGrpcClientWithTimeout(endpoint, 30*time.Second)
+	err := c.Start(grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err, "failed to connect to %s", endpoint)
+	t.Cleanup(c.Stop)
+
+	_, err = c.EstimateEnergy(
+		nileTestAccountAddress,
+		nileUSDTContract,
+		"balanceOf(address)",
+		`[{"address": "`+nileTestAccountAddress+`"}]`,
+		0, "", 0,
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, client.ErrEstimateEnergyNotSupported),
+		"expected ErrEstimateEnergyNotSupported, got: %v", err)
 }
 
 func TestIntegration_DeployContract(t *testing.T) {

--- a/pkg/client/contracts_test.go
+++ b/pkg/client/contracts_test.go
@@ -3,15 +3,19 @@ package client_test
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"math/big"
 	"testing"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/abi"
+	client "github.com/fbsobreira/gotron-sdk/pkg/client"
 	"github.com/fbsobreira/gotron-sdk/pkg/contract"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 )
@@ -103,6 +107,26 @@ func TestEstimateEnergy(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, estimate.Result.Result)
 	assert.Equal(t, int64(20000), estimate.EnergyRequired)
+}
+
+func TestEstimateEnergyNotSupported(t *testing.T) {
+	mock := &mockWalletServer{
+		EstimateEnergyFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.EstimateEnergyMessage, error) {
+			return nil, status.Error(codes.Unimplemented, "method not found")
+		},
+	}
+
+	c := newMockClient(t, mock)
+
+	_, err := c.EstimateEnergy(
+		"TTGhREx2pDSxFX555NWz1YwGpiBVPvQA7e",
+		"TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
+		"transfer(address,uint256)",
+		`[{"address": "TE4c73WubeWPhSF1nAovQDmQytjcaLZyY9"},{"uint256": "100"}]`,
+		0, "", 0,
+	)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, client.ErrEstimateEnergyNotSupported))
 }
 
 func TestGetAccount(t *testing.T) {

--- a/pkg/client/errors.go
+++ b/pkg/client/errors.go
@@ -1,0 +1,7 @@
+package client
+
+import "errors"
+
+// ErrEstimateEnergyNotSupported is returned when the connected TRON node
+// does not support the EstimateEnergy RPC.
+var ErrEstimateEnergyNotSupported = errors.New("this node does not support estimate energy")


### PR DESCRIPTION
## Summary

- Add `ErrEstimateEnergyNotSupported` sentinel error in `pkg/client/errors.go`
- Wrap gRPC `Unimplemented` errors in `estimateEnergy` so callers can use `errors.Is()` instead of string matching
- Add unit test for the unsupported-node error path
- Add integration test (`TRON_UNSUPPORTED_ENDPOINT` env var) for on-chain validation against nodes that lack EstimateEnergy support

Closes #213

## Test plan

- [x] Unit test `TestEstimateEnergyNotSupported` — mocks gRPC `Unimplemented` and asserts sentinel
- [x] Unit test `TestEstimateEnergy` — existing happy path still passes
- [x] Integration test `TestIntegration_EstimateEnergy` — verified on Nile testnet
- [x] Integration test `TestIntegration_EstimateEnergyNotSupported` — skipped without env var, runs against configured endpoint
- [x] `make test` — all tests pass
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for energy estimation requests on nodes that don't support this feature, providing clearer error messages to distinguish this scenario from other failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->