### PR TITLE
feat(client): add witness address helpers for block responses

### DIFF
--- a/pkg/client/block_helpers.go
+++ b/pkg/client/block_helpers.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"github.com/fbsobreira/gotron-sdk/pkg/address"
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+)
+
+// blockHeaderWitnessAddress extracts the witness address from a BlockHeader.
+// Returns nil if the header or raw data is nil, if the witness address is empty,
+// or if the bytes do not form a valid TRON address.
+// The returned Address is a copy and does not alias the protobuf backing array.
+func blockHeaderWitnessAddress(header *core.BlockHeader) address.Address {
+	if header == nil || header.RawData == nil || len(header.RawData.WitnessAddress) == 0 {
+		return nil
+	}
+	buf := make([]byte, len(header.RawData.WitnessAddress))
+	copy(buf, header.RawData.WitnessAddress)
+	addr := address.Address(buf)
+	if !addr.IsValid() {
+		return nil
+	}
+	return addr
+}
+
+// BlockExtentionWitnessAddress returns the witness address from a BlockExtention
+// as an address.Address. Returns nil if the block or header is nil.
+func BlockExtentionWitnessAddress(block *api.BlockExtention) address.Address {
+	if block == nil {
+		return nil
+	}
+	return blockHeaderWitnessAddress(block.BlockHeader)
+}
+
+// BlockExtentionWitnessBase58 returns the witness address from a BlockExtention
+// as a base58-encoded string. Returns an empty string if the block or header is nil.
+func BlockExtentionWitnessBase58(block *api.BlockExtention) string {
+	addr := BlockExtentionWitnessAddress(block)
+	if addr == nil {
+		return ""
+	}
+	return addr.String()
+}
+
+// BlockWitnessAddress returns the witness address from a Block
+// as an address.Address. Returns nil if the block or header is nil.
+func BlockWitnessAddress(block *core.Block) address.Address {
+	if block == nil {
+		return nil
+	}
+	return blockHeaderWitnessAddress(block.BlockHeader)
+}
+
+// BlockWitnessBase58 returns the witness address from a Block
+// as a base58-encoded string. Returns an empty string if the block or header is nil.
+func BlockWitnessBase58(block *core.Block) string {
+	addr := BlockWitnessAddress(block)
+	if addr == nil {
+		return ""
+	}
+	return addr.String()
+}

--- a/pkg/client/block_helpers_test.go
+++ b/pkg/client/block_helpers_test.go
@@ -1,0 +1,230 @@
+package client_test
+
+import (
+	"testing"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/address"
+	"github.com/fbsobreira/gotron-sdk/pkg/client"
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testWitnessBase58 is a known valid TRON address used as test fixture.
+const testWitnessBase58 = "TPL66VK2gCXNCD7EJg9pgJRfqcRazjhUZY"
+
+// testWitnessBytes returns a fresh copy of the witness address bytes for each test.
+func testWitnessBytes(t *testing.T) []byte {
+	t.Helper()
+	addr, err := address.Base58ToAddress(testWitnessBase58)
+	require.NoError(t, err)
+	require.True(t, addr.IsValid())
+	return addr.Bytes()
+}
+
+func TestBlockExtentionWitnessAddress(t *testing.T) {
+	wb := testWitnessBytes(t)
+
+	tests := []struct {
+		name  string
+		block *api.BlockExtention
+		want  address.Address
+	}{
+		{
+			name:  "nil block",
+			block: nil,
+			want:  nil,
+		},
+		{
+			name:  "nil block header",
+			block: &api.BlockExtention{},
+			want:  nil,
+		},
+		{
+			name:  "nil raw data",
+			block: &api.BlockExtention{BlockHeader: &core.BlockHeader{}},
+			want:  nil,
+		},
+		{
+			name: "empty witness address",
+			block: &api.BlockExtention{BlockHeader: &core.BlockHeader{
+				RawData: &core.BlockHeaderRaw{WitnessAddress: []byte{}},
+			}},
+			want: nil,
+		},
+		{
+			name: "invalid witness address (wrong length)",
+			block: &api.BlockExtention{BlockHeader: &core.BlockHeader{
+				RawData: &core.BlockHeaderRaw{WitnessAddress: []byte{0x41, 0x01, 0x02}},
+			}},
+			want: nil,
+		},
+		{
+			name: "valid witness address",
+			block: &api.BlockExtention{BlockHeader: &core.BlockHeader{
+				RawData: &core.BlockHeaderRaw{WitnessAddress: wb},
+			}},
+			want: address.Address(wb),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := client.BlockExtentionWitnessAddress(tt.block)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBlockExtentionWitnessBase58(t *testing.T) {
+	wb := testWitnessBytes(t)
+
+	tests := []struct {
+		name  string
+		block *api.BlockExtention
+		want  string
+	}{
+		{
+			name:  "nil block",
+			block: nil,
+			want:  "",
+		},
+		{
+			name:  "nil block header",
+			block: &api.BlockExtention{},
+			want:  "",
+		},
+		{
+			name:  "nil raw data",
+			block: &api.BlockExtention{BlockHeader: &core.BlockHeader{}},
+			want:  "",
+		},
+		{
+			name: "valid witness address",
+			block: &api.BlockExtention{BlockHeader: &core.BlockHeader{
+				RawData: &core.BlockHeaderRaw{WitnessAddress: wb},
+			}},
+			want: testWitnessBase58,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := client.BlockExtentionWitnessBase58(tt.block)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBlockWitnessAddress(t *testing.T) {
+	wb := testWitnessBytes(t)
+
+	tests := []struct {
+		name  string
+		block *core.Block
+		want  address.Address
+	}{
+		{
+			name:  "nil block",
+			block: nil,
+			want:  nil,
+		},
+		{
+			name:  "nil block header",
+			block: &core.Block{},
+			want:  nil,
+		},
+		{
+			name:  "nil raw data",
+			block: &core.Block{BlockHeader: &core.BlockHeader{}},
+			want:  nil,
+		},
+		{
+			name: "empty witness address",
+			block: &core.Block{BlockHeader: &core.BlockHeader{
+				RawData: &core.BlockHeaderRaw{WitnessAddress: []byte{}},
+			}},
+			want: nil,
+		},
+		{
+			name: "invalid witness address (wrong length)",
+			block: &core.Block{BlockHeader: &core.BlockHeader{
+				RawData: &core.BlockHeaderRaw{WitnessAddress: []byte{0x41, 0x01, 0x02}},
+			}},
+			want: nil,
+		},
+		{
+			name: "valid witness address",
+			block: &core.Block{BlockHeader: &core.BlockHeader{
+				RawData: &core.BlockHeaderRaw{WitnessAddress: wb},
+			}},
+			want: address.Address(wb),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := client.BlockWitnessAddress(tt.block)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBlockWitnessBase58(t *testing.T) {
+	wb := testWitnessBytes(t)
+
+	tests := []struct {
+		name  string
+		block *core.Block
+		want  string
+	}{
+		{
+			name:  "nil block",
+			block: nil,
+			want:  "",
+		},
+		{
+			name:  "nil block header",
+			block: &core.Block{},
+			want:  "",
+		},
+		{
+			name:  "nil raw data",
+			block: &core.Block{BlockHeader: &core.BlockHeader{}},
+			want:  "",
+		},
+		{
+			name: "valid witness address",
+			block: &core.Block{BlockHeader: &core.BlockHeader{
+				RawData: &core.BlockHeaderRaw{WitnessAddress: wb},
+			}},
+			want: testWitnessBase58,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := client.BlockWitnessBase58(tt.block)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestBlockExtentionWitnessAddress_does_not_alias_protobuf(t *testing.T) {
+	wb := testWitnessBytes(t)
+	block := &api.BlockExtention{BlockHeader: &core.BlockHeader{
+		RawData: &core.BlockHeaderRaw{WitnessAddress: wb},
+	}}
+
+	addr := client.BlockExtentionWitnessAddress(block)
+	require.NotNil(t, addr)
+
+	// Mutate the returned address; the protobuf field must be unchanged.
+	original := make([]byte, len(wb))
+	copy(original, wb)
+	addr[0] = 0x00
+
+	assert.Equal(t, original, []byte(block.BlockHeader.RawData.WitnessAddress),
+		"mutating the returned Address must not affect the protobuf message")
+}


### PR DESCRIPTION
## Summary

Closes #214

- Add `BlockExtentionWitnessAddress` / `BlockExtentionWitnessBase58` helpers for `*api.BlockExtention`
- Add `BlockWitnessAddress` / `BlockWitnessBase58` helpers for `*core.Block`
- Validates address with `IsValid()` (rejects malformed bytes)
- Returns a defensive copy to avoid aliasing the protobuf backing array
- 21 table-driven tests covering nil blocks, nil headers, nil raw data, empty bytes, invalid length, valid addresses, and mutation safety

### Before

```go
witnessHex := hex.EncodeToString(block.BlockHeader.RawData.WitnessAddress)
witnessAddr := address.HexToAddress(witnessHex)
base58 := witnessAddr.String()
```

### After

```go
base58 := client.BlockExtentionWitnessBase58(block)
```

## Test plan

- [x] `make goimports` passes
- [x] `make lint` passes (0 issues)
- [x] `make test` passes (all packages)
- [x] `pkg/client` coverage: 84.4%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* New API methods for retrieving witness addresses from blockchain blocks
* Multiple address format representations (address objects and base58 strings)
* Robust handling of edge cases with nil-safe operations

## Tests
* Extensive test suite for address retrieval functions covering various scenarios and data conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->