### PR TITLE
fix(keystore): stabilize flaky TestClose goroutine assertions

### DIFF
--- a/pkg/keystore/keystore_test.go
+++ b/pkg/keystore/keystore_test.go
@@ -784,13 +784,11 @@ func TestClose(t *testing.T) {
 			ks.Close()
 		}
 
-		// Allow goroutines to wind down
-		time.Sleep(100 * time.Millisecond)
-
-		after := runtime.NumGoroutine()
-		// We allow a small margin for other background goroutines
-		assert.LessOrEqual(t, after, baseline+2,
-			"goroutine count should return near baseline after closing keystores (baseline=%d, after=%d)", baseline, after)
+		// Poll for goroutines to wind down instead of a fixed sleep.
+		assert.Eventually(t, func() bool {
+			return runtime.NumGoroutine() <= baseline+2
+		}, 2*time.Second, 50*time.Millisecond,
+			"goroutine count should return near baseline after closing keystores (baseline=%d)", baseline)
 	})
 
 	t.Run("close is safe to call on unused keystore", func(t *testing.T) {
@@ -815,11 +813,10 @@ func TestClose(t *testing.T) {
 		// Close while subscriber is still active — should terminate the updater
 		ks.Close()
 
-		time.Sleep(100 * time.Millisecond)
-
-		after := runtime.NumGoroutine()
-		assert.LessOrEqual(t, after, baseline,
-			"goroutine count should not grow after Close with active subscriber (baseline=%d, after=%d)", baseline, after)
+		assert.Eventually(t, func() bool {
+			return runtime.NumGoroutine() <= baseline
+		}, 2*time.Second, 50*time.Millisecond,
+			"goroutine count should not grow after Close with active subscriber (baseline=%d)", baseline)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Replace `time.Sleep(100ms)` + point-in-time goroutine count assertions with `assert.Eventually` (polls every 50ms, up to 2s)
- Fixes intermittent CI failures on Go 1.24 with `-race` where goroutines hadn't fully wound down within the fixed 100ms window

## Test plan

- [x] `go test -race -run TestClose ./pkg/keystore/ -count=5` passes consistently
- [x] `make lint` passes (0 issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing fixed delays with polling-based assertions for goroutine synchronization verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->