### PR TITLE
feat(abi): add ABI output decoding helpers for TriggerConstantContract results

### DIFF
--- a/pkg/abi/abi.go
+++ b/pkg/abi/abi.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/big"
+	"reflect"
 	"strconv"
 	"strings"
 
@@ -481,14 +482,172 @@ func ParseTopicsIntoMap(out map[string]interface{}, fields eABI.Arguments, topic
 	// Convert any Ethereum addresses to TRON addresses
 	for k, v := range out {
 		if addr, ok := v.(eCommon.Address); ok {
-			addrBytes := make([]byte, 1+len(addr.Bytes()))
-			addrBytes[0] = address.TronBytePrefix
-			copy(addrBytes[1:], addr.Bytes())
-			out[k] = address.Address(addrBytes)
+			out[k] = ethToTronAddress(addr)
 		}
 	}
 
 	return nil
+}
+
+// revertSelector is the 4-byte function selector for Error(string),
+// used by Solidity's revert/require statements.
+var revertSelector = [4]byte{0x08, 0xc3, 0x79, 0xa0}
+
+// panicSelector is the 4-byte function selector for Panic(uint256),
+// emitted by Solidity for assertion failures, arithmetic overflow, etc.
+var panicSelector = [4]byte{0x4e, 0x48, 0x7b, 0x71}
+
+// panicReasons maps Solidity panic codes to human-readable descriptions.
+var panicReasons = map[uint8]string{
+	0x00: "generic compiler panic",
+	0x01: "assertion failure",
+	0x11: "arithmetic overflow/underflow",
+	0x12: "division or modulo by zero",
+	0x21: "invalid enum conversion",
+	0x22: "invalid storage byte array encoding",
+	0x31: "pop on empty array",
+	0x32: "array index out of bounds",
+	0x41: "out of memory",
+	0x51: "zero-initialized function pointer call",
+}
+
+// ethToTronAddress converts an Ethereum common.Address to a TRON address
+// by prepending the 0x41 prefix byte.
+func ethToTronAddress(addr eCommon.Address) address.Address {
+	tronAddr := make([]byte, 1+len(addr.Bytes()))
+	tronAddr[0] = address.TronBytePrefix
+	copy(tronAddr[1:], addr.Bytes())
+	return address.Address(tronAddr)
+}
+
+// DecodeOutput decodes ABI-encoded output bytes from a constant contract call
+// into a slice of typed values. Addresses are automatically converted from
+// Ethereum format to TRON base58 format.
+func DecodeOutput(contractABI *core.SmartContract_ABI, method string, data []byte) ([]interface{}, error) {
+	args, err := GetParser(contractABI, method)
+	if err != nil {
+		return nil, fmt.Errorf("get output parser: %w", err)
+	}
+
+	// Functions with no declared outputs produce empty data — return early.
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	if len(data) == 0 {
+		return nil, fmt.Errorf("empty output data")
+	}
+
+	values, err := args.UnpackValues(data)
+	if err != nil {
+		return nil, fmt.Errorf("unpack output: %w", err)
+	}
+
+	// Convert Ethereum addresses to TRON addresses in-place.
+	for i, v := range values {
+		values[i] = convertOutputValue(v)
+	}
+
+	return values, nil
+}
+
+// convertOutputValue converts Ethereum addresses to TRON addresses in decoded
+// ABI output values. Handles single addresses, address slices, and fixed-size
+// address arrays (e.g. [3]common.Address). For unrecognized types, the value
+// is returned unchanged.
+func convertOutputValue(v interface{}) interface{} {
+	switch val := v.(type) {
+	case eCommon.Address:
+		return ethToTronAddress(val)
+	case []eCommon.Address:
+		result := make([]address.Address, len(val))
+		for i, addr := range val {
+			result[i] = ethToTronAddress(addr)
+		}
+		return result
+	default:
+		// Handle fixed-size address arrays ([N]common.Address) which
+		// go-ethereum returns for Solidity fixed-size array outputs.
+		rv := reflect.ValueOf(v)
+		if rv.Kind() == reflect.Array && rv.Type().Elem() == reflect.TypeOf(eCommon.Address{}) {
+			result := make([]address.Address, rv.Len())
+			for i := range result {
+				result[i] = ethToTronAddress(rv.Index(i).Interface().(eCommon.Address))
+			}
+			return result
+		}
+		return v
+	}
+}
+
+// DecodeRevertReason extracts the human-readable error string from
+// ABI-encoded revert data. Supports both Error(string) (selector 0x08c379a0)
+// from revert/require and Panic(uint256) (selector 0x4e487b71) from
+// assertion failures and arithmetic errors.
+func DecodeRevertReason(data []byte) (string, error) {
+	if len(data) < 4 {
+		return "", fmt.Errorf("data too short for revert selector: %d bytes", len(data))
+	}
+
+	selector := [4]byte(data[:4])
+
+	switch selector {
+	case revertSelector:
+		return decodeErrorString(data[4:])
+	case panicSelector:
+		return decodePanicReason(data[4:])
+	default:
+		return "", fmt.Errorf("unknown error selector: 0x%x", data[:4])
+	}
+}
+
+// decodeErrorString decodes the ABI-encoded string from Error(string) revert data.
+func decodeErrorString(data []byte) (string, error) {
+	strTy, err := eABI.NewType("string", "", nil)
+	if err != nil {
+		return "", fmt.Errorf("create string type: %w", err)
+	}
+
+	args := eABI.Arguments{{Type: strTy}}
+	values, err := args.UnpackValues(data)
+	if err != nil {
+		return "", fmt.Errorf("unpack revert reason: %w", err)
+	}
+
+	reason, ok := values[0].(string)
+	if !ok {
+		return "", fmt.Errorf("unexpected revert reason type: %T", values[0])
+	}
+
+	return reason, nil
+}
+
+// decodePanicReason decodes the ABI-encoded uint256 from Panic(uint256) data
+// and returns a human-readable description of the panic code.
+func decodePanicReason(data []byte) (string, error) {
+	uintTy, err := eABI.NewType("uint256", "", nil)
+	if err != nil {
+		return "", fmt.Errorf("create uint256 type: %w", err)
+	}
+
+	args := eABI.Arguments{{Type: uintTy}}
+	values, err := args.UnpackValues(data)
+	if err != nil {
+		return "", fmt.Errorf("unpack panic code: %w", err)
+	}
+
+	code, ok := values[0].(*big.Int)
+	if !ok {
+		return "", fmt.Errorf("unexpected panic code type: %T", values[0])
+	}
+
+	if code.IsUint64() && code.Uint64() <= 0xFF {
+		if desc, found := panicReasons[uint8(code.Uint64())]; found {
+			return fmt.Sprintf("panic: %s (0x%02x)", desc, code.Uint64()), nil
+		}
+	}
+
+	return fmt.Sprintf("panic: unknown code (0x%x)", code), nil
 }
 
 // GetInputsParser returns input method parser arguments from ABI

--- a/pkg/abi/abi_test.go
+++ b/pkg/abi/abi_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	eABI "github.com/ethereum/go-ethereum/accounts/abi"
+	eCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/address"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
 	"github.com/stretchr/testify/assert"
@@ -441,6 +442,393 @@ func TestGetEventParser(t *testing.T) {
 	// Should not find nonexistent event
 	_, _, err = GetEventParser(contractABI, "Approval")
 	require.Error(t, err)
+}
+
+func TestDecodeOutput_SingleUint256(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "totalSupply",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "", Type: "uint256"},
+				},
+			},
+		},
+	}
+
+	// ABI-encode uint256(1000)
+	val := new(big.Int).SetInt64(1000)
+	data := eCommon.LeftPadBytes(val.Bytes(), 32)
+
+	result, err := DecodeOutput(contractABI, "totalSupply", data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	decoded, ok := result[0].(*big.Int)
+	require.True(t, ok, "expected *big.Int, got %T", result[0])
+	assert.Equal(t, int64(1000), decoded.Int64())
+}
+
+func TestDecodeOutput_Bool(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "paused",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "", Type: "bool"},
+				},
+			},
+		},
+	}
+
+	// ABI-encode bool(true) — 32 bytes, last byte = 1
+	data := make([]byte, 32)
+	data[31] = 1
+
+	result, err := DecodeOutput(contractABI, "paused", data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, true, result[0])
+}
+
+func TestDecodeOutput_Address(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "owner",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "", Type: "address"},
+				},
+			},
+		},
+	}
+
+	// ABI-encode an address (20 bytes, left-padded to 32)
+	ethAddr := make([]byte, 32)
+	for i := 12; i < 32; i++ {
+		ethAddr[i] = byte(i - 12 + 1) // 0x01..0x14
+	}
+
+	result, err := DecodeOutput(contractABI, "owner", ethAddr)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	tronAddr, ok := result[0].(address.Address)
+	require.True(t, ok, "expected address.Address, got %T", result[0])
+	assert.Equal(t, byte(0x41), tronAddr[0], "TRON address must start with 0x41")
+	assert.Equal(t, 21, len(tronAddr), "TRON address must be 21 bytes")
+}
+
+func TestDecodeOutput_MultipleReturns(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "getInfo",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "balance", Type: "uint256"},
+					{Name: "owner", Type: "address"},
+					{Name: "active", Type: "bool"},
+				},
+			},
+		},
+	}
+
+	// Pack: uint256(42) + address + bool(true)
+	data := make([]byte, 96)
+	// uint256(42)
+	data[31] = 42
+	// address — put 0xAB in last byte of the 20-byte address area
+	data[63] = 0xAB
+	// bool(true)
+	data[95] = 1
+
+	result, err := DecodeOutput(contractABI, "getInfo", data)
+	require.NoError(t, err)
+	require.Len(t, result, 3)
+
+	balance, ok := result[0].(*big.Int)
+	require.True(t, ok)
+	assert.Equal(t, int64(42), balance.Int64())
+
+	tronAddr, ok := result[1].(address.Address)
+	require.True(t, ok)
+	assert.Equal(t, byte(0x41), tronAddr[0])
+
+	assert.Equal(t, true, result[2])
+}
+
+func TestDecodeOutput_String(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "name",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "", Type: "string"},
+				},
+			},
+		},
+	}
+
+	// ABI-encode string "Tether USD":
+	// offset(32) + length(32) + data(32 padded)
+	eArgs := eABI.Arguments{{Type: mustNewType("string")}}
+	data, err := eArgs.Pack("Tether USD")
+	require.NoError(t, err)
+
+	result, err := DecodeOutput(contractABI, "name", data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+	assert.Equal(t, "Tether USD", result[0])
+}
+
+func TestDecodeOutput_AddressArray(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "getOwners",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "", Type: "address[]"},
+				},
+			},
+		},
+	}
+
+	eArgs := eABI.Arguments{{Type: mustNewType("address[]")}}
+	data, err := eArgs.Pack([]eCommon.Address{
+		eCommon.HexToAddress("0x0000000000000000000000000000000000000001"),
+		eCommon.HexToAddress("0x0000000000000000000000000000000000000002"),
+	})
+	require.NoError(t, err)
+
+	result, err := DecodeOutput(contractABI, "getOwners", data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	addrs, ok := result[0].([]address.Address)
+	require.True(t, ok, "expected []address.Address, got %T", result[0])
+	require.Len(t, addrs, 2)
+	assert.Equal(t, byte(0x41), addrs[0][0])
+	assert.Equal(t, byte(0x41), addrs[1][0])
+}
+
+func TestDecodeOutput_EmptyData(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "totalSupply",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "", Type: "uint256"},
+				},
+			},
+		},
+	}
+
+	_, err := DecodeOutput(contractABI, "totalSupply", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty output data")
+
+	_, err = DecodeOutput(contractABI, "totalSupply", []byte{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty output data")
+}
+
+func TestDecodeOutput_ZeroOutputFunction(t *testing.T) {
+	// Functions with returns() produce empty data — this is valid.
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "pause",
+				Type: core.SmartContract_ABI_Entry_Function,
+				// No Outputs
+			},
+		},
+	}
+
+	result, err := DecodeOutput(contractABI, "pause", nil)
+	require.NoError(t, err)
+	assert.Nil(t, result)
+
+	result, err = DecodeOutput(contractABI, "pause", []byte{})
+	require.NoError(t, err)
+	assert.Nil(t, result)
+}
+
+func TestDecodeOutput_FixedSizeAddressArray(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "getTopThree",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "", Type: "address[3]"},
+				},
+			},
+		},
+	}
+
+	// Pack 3 addresses using go-ethereum's ABI encoder.
+	ty, err := eABI.NewType("address[3]", "", nil)
+	require.NoError(t, err)
+	eArgs := eABI.Arguments{{Type: ty}}
+	data, err := eArgs.Pack([3]eCommon.Address{
+		eCommon.HexToAddress("0x0000000000000000000000000000000000000001"),
+		eCommon.HexToAddress("0x0000000000000000000000000000000000000002"),
+		eCommon.HexToAddress("0x0000000000000000000000000000000000000003"),
+	})
+	require.NoError(t, err)
+
+	result, err := DecodeOutput(contractABI, "getTopThree", data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	addrs, ok := result[0].([]address.Address)
+	require.True(t, ok, "expected []address.Address, got %T", result[0])
+	require.Len(t, addrs, 3)
+	for i, addr := range addrs {
+		assert.Equal(t, byte(0x41), addr[0], "address[%d] should be TRON format", i)
+	}
+}
+
+func TestDecodeOutput_Bytes32(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{
+			{
+				Name: "getHash",
+				Type: core.SmartContract_ABI_Entry_Function,
+				Outputs: []*core.SmartContract_ABI_Entry_Param{
+					{Name: "", Type: "bytes32"},
+				},
+			},
+		},
+	}
+
+	expected := [32]byte{0xde, 0xad, 0xbe, 0xef}
+	eArgs := eABI.Arguments{{Type: mustNewType("bytes32")}}
+	data, err := eArgs.Pack(expected)
+	require.NoError(t, err)
+
+	result, err := DecodeOutput(contractABI, "getHash", data)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	decoded, ok := result[0].([32]byte)
+	require.True(t, ok, "expected [32]byte, got %T", result[0])
+	assert.Equal(t, expected, decoded)
+}
+
+func TestDecodeOutput_MethodNotFound(t *testing.T) {
+	contractABI := &core.SmartContract_ABI{
+		Entrys: []*core.SmartContract_ABI_Entry{},
+	}
+
+	_, err := DecodeOutput(contractABI, "doesNotExist", []byte{0x01})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get output parser")
+}
+
+func TestDecodeOutput_OverloadedMethod(t *testing.T) {
+	contractABI := makeOverloadedABI()
+
+	// Encode (uint256(7), bool(true)) for rollDice(uint256,uint256,address)
+	eArgs := eABI.Arguments{
+		{Type: mustNewType("uint256")},
+		{Type: mustNewType("bool")},
+	}
+	data, err := eArgs.Pack(big.NewInt(7), true)
+	require.NoError(t, err)
+
+	result, err := DecodeOutput(contractABI, "rollDice(uint256,uint256,address)", data)
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+
+	val, ok := result[0].(*big.Int)
+	require.True(t, ok)
+	assert.Equal(t, int64(7), val.Int64())
+	assert.Equal(t, true, result[1])
+}
+
+func TestDecodeRevertReason_Valid(t *testing.T) {
+	// Build revert data: selector(4) + ABI-encoded string
+	eArgs := eABI.Arguments{{Type: mustNewType("string")}}
+	encodedMsg, err := eArgs.Pack("insufficient balance")
+	require.NoError(t, err)
+
+	data := append([]byte{0x08, 0xc3, 0x79, 0xa0}, encodedMsg...)
+
+	reason, err := DecodeRevertReason(data)
+	require.NoError(t, err)
+	assert.Equal(t, "insufficient balance", reason)
+}
+
+func TestDecodeRevertReason_EmptyMessage(t *testing.T) {
+	eArgs := eABI.Arguments{{Type: mustNewType("string")}}
+	encodedMsg, err := eArgs.Pack("")
+	require.NoError(t, err)
+
+	data := append([]byte{0x08, 0xc3, 0x79, 0xa0}, encodedMsg...)
+
+	reason, err := DecodeRevertReason(data)
+	require.NoError(t, err)
+	assert.Equal(t, "", reason)
+}
+
+func TestDecodeRevertReason_TooShort(t *testing.T) {
+	_, err := DecodeRevertReason([]byte{0x08, 0xc3})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestDecodeRevertReason_WrongSelector(t *testing.T) {
+	data := make([]byte, 36)
+	data[0] = 0xFF // wrong selector
+
+	_, err := DecodeRevertReason(data)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown error selector")
+}
+
+func TestDecodeRevertReason_Panic(t *testing.T) {
+	// Build Panic(uint256) data: selector(4) + ABI-encoded uint256
+	eArgs := eABI.Arguments{{Type: mustNewType("uint256")}}
+
+	tests := []struct {
+		name     string
+		code     *big.Int
+		contains string
+	}{
+		{"overflow", big.NewInt(0x11), "arithmetic overflow/underflow"},
+		{"assertion", big.NewInt(0x01), "assertion failure"},
+		{"div by zero", big.NewInt(0x12), "division or modulo by zero"},
+		{"unknown code", big.NewInt(0xFF), "unknown code"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := eArgs.Pack(tc.code)
+			require.NoError(t, err)
+
+			data := append([]byte{0x4e, 0x48, 0x7b, 0x71}, encoded...)
+			reason, err := DecodeRevertReason(data)
+			require.NoError(t, err)
+			assert.Contains(t, reason, tc.contains)
+		})
+	}
+}
+
+// mustNewType creates an eABI.Type, panicking on error. Test helper only.
+func mustNewType(typeName string) eABI.Type {
+	ty, err := eABI.NewType(typeName, "", nil)
+	if err != nil {
+		panic(fmt.Sprintf("bad type %q: %v", typeName, err))
+	}
+	return ty
 }
 
 func TestEntrySignature_UsesRawTypes(t *testing.T) {

--- a/pkg/client/contracts_integration_test.go
+++ b/pkg/client/contracts_integration_test.go
@@ -4,11 +4,14 @@ package client_test
 
 import (
 	"errors"
+	"math/big"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/fbsobreira/gotron-sdk/pkg/abi"
+	"github.com/fbsobreira/gotron-sdk/pkg/address"
 	"github.com/fbsobreira/gotron-sdk/pkg/client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,6 +114,75 @@ func TestIntegration_TriggerConstantContract(t *testing.T) {
 	require.NotNil(t, result)
 	require.NotEmpty(t, result.GetConstantResult(), "totalSupply() should return a result")
 	assert.Len(t, result.GetConstantResult()[0], 32, "totalSupply() should return a 32-byte uint256")
+}
+
+func TestIntegration_DecodeOutput(t *testing.T) {
+	c := newIntegrationClient(t)
+
+	// Fetch the USDT contract ABI from chain.
+	contractABI, err := c.GetContractABI(nileUSDTContract)
+	require.NoError(t, err)
+	require.NotNil(t, contractABI)
+
+	t.Run("totalSupply_uint256", func(t *testing.T) {
+		tx, err := c.TriggerConstantContract("", nileUSDTContract, "totalSupply()", "[]")
+		require.NoError(t, err)
+		require.NotEmpty(t, tx.GetConstantResult())
+
+		values, err := abi.DecodeOutput(contractABI, "totalSupply", tx.GetConstantResult()[0])
+		require.NoError(t, err)
+		require.Len(t, values, 1)
+
+		supply, ok := values[0].(*big.Int)
+		require.True(t, ok, "expected *big.Int, got %T", values[0])
+		assert.True(t, supply.Sign() > 0, "totalSupply should be positive, got %s", supply)
+		t.Logf("totalSupply = %s", supply)
+	})
+
+	t.Run("name_string", func(t *testing.T) {
+		tx, err := c.TriggerConstantContract("", nileUSDTContract, "name()", "[]")
+		require.NoError(t, err)
+		require.NotEmpty(t, tx.GetConstantResult())
+
+		values, err := abi.DecodeOutput(contractABI, "name", tx.GetConstantResult()[0])
+		require.NoError(t, err)
+		require.Len(t, values, 1)
+
+		name, ok := values[0].(string)
+		require.True(t, ok, "expected string, got %T", values[0])
+		assert.NotEmpty(t, name, "name should not be empty")
+		t.Logf("name = %q", name)
+	})
+
+	t.Run("decimals_uint8", func(t *testing.T) {
+		tx, err := c.TriggerConstantContract("", nileUSDTContract, "decimals()", "[]")
+		require.NoError(t, err)
+		require.NotEmpty(t, tx.GetConstantResult())
+
+		values, err := abi.DecodeOutput(contractABI, "decimals", tx.GetConstantResult()[0])
+		require.NoError(t, err)
+		require.Len(t, values, 1)
+
+		decimals, ok := values[0].(uint8)
+		require.True(t, ok, "expected uint8, got %T", values[0])
+		assert.Equal(t, uint8(6), decimals, "USDT should have 6 decimals")
+		t.Logf("decimals = %d", decimals)
+	})
+
+	t.Run("owner_address", func(t *testing.T) {
+		tx, err := c.TriggerConstantContract("", nileUSDTContract, "owner()", "[]")
+		require.NoError(t, err)
+		require.NotEmpty(t, tx.GetConstantResult())
+
+		values, err := abi.DecodeOutput(contractABI, "owner", tx.GetConstantResult()[0])
+		require.NoError(t, err)
+		require.Len(t, values, 1)
+
+		ownerAddr, ok := values[0].(address.Address)
+		require.True(t, ok, "expected address.Address, got %T", values[0])
+		assert.Equal(t, byte(0x41), ownerAddr[0], "should be TRON address")
+		t.Logf("owner = %s", ownerAddr.String())
+	})
 }
 
 func TestIntegration_TriggerContract(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `DecodeOutput()` to decode ABI-encoded bytes from `TriggerConstantContract` into typed Go values with automatic Ethereum-to-TRON address conversion (single addresses, slices, and fixed-size arrays)
- Add `DecodeRevertReason()` to extract human-readable error strings from `Error(string)` and `Panic(uint256)` revert data
- Extract `ethToTronAddress()` helper to deduplicate address conversion across `DecodeOutput`, `convertOutputValue`, and `ParseTopicsIntoMap`

## Test plan

- [x] 17 unit tests covering: uint256, bool, string, address, address[], address[N], bytes32, multiple returns, overloaded methods, empty data, zero-output functions, method not found, revert reasons (valid, empty, too short, wrong selector), and panic codes (overflow, assertion, div-by-zero, unknown)
- [x] Integration test against Nile testnet USDT contract: `totalSupply` (uint256), `name` (string), `decimals` (uint8), `owner` (address)
- [x] `make goimports` — clean
- [x] `make lint` — 0 issues
- [x] `make test` — all pass, 95.8% coverage on `pkg/abi`

Closes #216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added ABI output decoding functionality for contract method results
  * Added revert reason decoding to display human-readable error messages
  * Automatic conversion of Ethereum addresses to TRON addresses in decoded outputs

* **Tests**
  * Comprehensive test coverage for output decoding across various data types
  * Integration tests for contract decoding functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->