### PR TITLE
feat(client): add context propagation support to GrpcClient

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,6 +18,7 @@ type GrpcClient struct {
 	grpcTimeout time.Duration
 	opts        []grpc.DialOption
 	apiKey      string
+	baseCtx     context.Context
 }
 
 // NewGrpcClient create grpc controller
@@ -64,8 +65,27 @@ func (g *GrpcClient) SetAPIKey(apiKey string) error {
 	return nil
 }
 
+// SetContext sets a base context for all RPC calls.
+// This allows callers to propagate cancellation, deadlines, and tracing metadata.
+// If not set, context.Background() is used.
+//
+// Note: cancelling the base context will cause all subsequent RPCs on this
+// client to fail immediately. SetContext must not be called concurrently
+// with RPC methods.
+func (g *GrpcClient) SetContext(ctx context.Context) error {
+	if ctx == nil {
+		return fmt.Errorf("gotron: nil context")
+	}
+	g.baseCtx = ctx
+	return nil
+}
+
 func (g *GrpcClient) getContext() (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithTimeout(context.Background(), g.grpcTimeout)
+	base := g.baseCtx
+	if base == nil {
+		base = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(base, g.grpcTimeout)
 	if len(g.apiKey) > 0 {
 		ctx = metadata.AppendToOutgoingContext(ctx, "TRON-PRO-API-KEY", g.apiKey)
 	}

--- a/pkg/client/client_extra_test.go
+++ b/pkg/client/client_extra_test.go
@@ -260,6 +260,56 @@ func TestGetBlockByNum(t *testing.T) {
 	assert.Equal(t, int64(999), block.BlockHeader.RawData.Number)
 }
 
+func TestSetContext_CancellationPropagated(t *testing.T) {
+	mock := &mockWalletServer{
+		GetNextMaintenanceTimeFunc: func(ctx context.Context, _ *api.EmptyMessage) (*api.NumberMessage, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	c := newMockClient(t, mock)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel
+	require.NoError(t, c.SetContext(ctx))
+
+	_, err := c.GetNextMaintenanceTime()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Canceled")
+}
+
+func TestSetContext_DeadlinePropagated(t *testing.T) {
+	mock := &mockWalletServer{
+		GetNextMaintenanceTimeFunc: func(ctx context.Context, _ *api.EmptyMessage) (*api.NumberMessage, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		},
+	}
+
+	c := newMockClient(t, mock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	require.NoError(t, c.SetContext(ctx))
+
+	start := time.Now()
+	_, err := c.GetNextMaintenanceTime()
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DeadlineExceeded")
+	assert.Less(t, elapsed, 1*time.Second)
+}
+
+func TestSetContext_NilReturnsError(t *testing.T) {
+	c := client.NewGrpcClient("localhost:50051")
+	//nolint:staticcheck // SA1012: intentionally passing nil to test error guard
+	err := c.SetContext(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil context")
+}
+
 func TestGetAccountResource(t *testing.T) {
 	mock := &mockWalletServer{
 		GetAccountResourceFunc: func(_ context.Context, _ *core.Account) (*api.AccountResourceMessage, error) {


### PR DESCRIPTION
## Summary

- Add `SetContext(ctx)` method to `GrpcClient` allowing callers to propagate cancellation, deadlines, and tracing metadata through all RPC calls
- Updated `getContext()` to use the base context as parent instead of always using `context.Background()`
- Returns error on nil context, documents concurrency constraints and cancellation behavior

## Test plan

- [x] `TestSetContext_CancellationPropagated` — pre-cancelled context propagates to RPCs
- [x] `TestSetContext_DeadlinePropagated` — parent deadline respected by derived context
- [x] `TestSetContext_NilReturnsError` — nil context returns error
- [x] Full test suite passes with `make test`
- [x] `make lint` and `make goimports` clean

Closes #227

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SetContext method enabling custom context configuration for RPC calls with support for request cancellation and deadline propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->