### PR TITLE
fix(cmd): show version info for go install builds

### DIFF
--- a/cmd/tronctl/main.go
+++ b/cmd/tronctl/main.go
@@ -47,7 +47,11 @@ func main() {
 	// notes one line 66,67 of https://golang.org/src/net/net.go that say can make the decision at
 	// build time.
 	_ = os.Setenv("GODEBUG", "netdns=go")
-	cmd.VersionWrapDump = version + "-" + commit
+	if commit != "" {
+		cmd.VersionWrapDump = version + "-" + commit
+	} else {
+		cmd.VersionWrapDump = version
+	}
 	cmd.RootCmd.AddCommand(&cobra.Command{
 		Use:   "version",
 		Short: "Show version",


### PR DESCRIPTION
## Summary

- Use `runtime/debug.ReadBuildInfo()` as fallback when ldflags are not set
- Shows module version and VCS info for `go install` builds
- GoReleaser builds are unaffected (ldflags take priority, `init` returns immediately)

**Before:** `tronctl version` → `TronCTL. tronctl version - ( )`
**After:** `tronctl version` → `TronCTL. tronctl version v0.25.0-bc2a392 ( 2026-03-18T00:32:00Z)`

## Test plan

- [x] Local `go build` shows `(devel)` + commit + build time
- [x] GoReleaser ldflags still take priority (init skips when version is set)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Runtime now captures and exposes build metadata (version, commit hash, build timestamp) when available.
  * Version output will include commit hash when present; falls back to existing version display if not.
  * No changes to public APIs or user-facing functionality.

---

Note: Primarily an internal metadata enhancement with minimal direct user impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->