### PR TITLE
fix(cmd): clean version output when commit/build info is empty

### DIFF
--- a/cmd/tronctl/main.go
+++ b/cmd/tronctl/main.go
@@ -56,9 +56,15 @@ func main() {
 		Use:   "version",
 		Short: "Show version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(os.Stderr,
-				"TronCTL. %v version %v-%v (%v %v)\n",
-				path.Base(os.Args[0]), version, commit, builtBy, builtAt)
+			ver := version
+			if commit != "" {
+				ver += "-" + commit
+			}
+			if builtBy != "" || builtAt != "" {
+				ver += fmt.Sprintf(" (%v %v)", builtBy, builtAt)
+			}
+			fmt.Fprintf(os.Stderr, "TronCTL. %v version %v\n",
+				path.Base(os.Args[0]), ver)
 			os.Exit(0)
 			return nil
 		},


### PR DESCRIPTION
## Summary

- Fix trailing hyphen and empty parens in `tronctl version` when installed via `go install`
- Only show commit suffix and build info when present

**Before:** `TronCTL. tronctl version v0.25.0- ( )`
**After:** `TronCTL. tronctl version v0.25.0`

## Test plan

- [x] `go install @version` (no VCS) → `tronctl version v0.25.0`
- [x] Local `go build` → `tronctl version (devel)-bc2a392 ( 2026-...)`
- [x] GoReleaser ldflags → `tronctl version v0.25.0-abc1234 (goreleaser 2026-...)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated version command output to display information in a single-line format, replacing the previous multi-part layout. Commit and build metadata now appear conditionally based on availability, providing a cleaner version display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->