### PR TITLE
ci: add Homebrew tap to GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,5 +43,17 @@ changelog:
       - "^ci:"
       - "^Merge "
 
+brews:
+  - repository:
+      owner: fbsobreira
+      name: homebrew-tap
+    homepage: https://github.com/fbsobreira/gotron-sdk
+    description: CLI tool for interacting with the TRON network
+    license: Apache-2.0
+    install: |
+      bin.install "tronctl"
+    test: |
+      system "#{bin}/tronctl", "version"
+
 release:
   prerelease: auto


### PR DESCRIPTION
## Summary

- Add `brews` section to `.goreleaser.yaml` to auto-publish Homebrew formula on release
- Formula is pushed to `fbsobreira/homebrew-tap`

## Usage

After next release:
```bash
brew install fbsobreira/tap/tronctl
```

## Test plan

- [x] GoReleaser config syntax is valid
- [x] Tap repo created: https://github.com/fbsobreira/homebrew-tap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Homebrew package distribution support to the release configuration, enabling installation via the Homebrew package manager with automated testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->