### PR TITLE
fix(keys): support BIP44 m/ prefix in NewParamsFromPath

### DIFF
--- a/pkg/keys/hd/hdwallet.go
+++ b/pkg/keys/hd/hdwallet.go
@@ -53,6 +53,7 @@ func NewParams(purpose, coinType, account uint32, change bool, addressIdx uint32
 
 // NewParamsFromPath parses the BIP44 path and unmarshals into the struct.
 func NewParamsFromPath(path string) (*BIP44Params, error) {
+	path = strings.TrimPrefix(path, "m/")
 	spl := strings.Split(path, "/")
 	if len(spl) != 5 {
 		return nil, fmt.Errorf("path length is wrong. Expected 5, got %d", len(spl))
@@ -172,6 +173,7 @@ func ComputeMastersFromSeed(seed []byte, masterSecret []byte) (secret [32]byte, 
 // using the given chainCode.
 func DerivePrivateKeyForPath(curve elliptic.Curve, privKeyBytes [32]byte, chainCode [32]byte, path string) ([32]byte, error) {
 	data := privKeyBytes
+	path = strings.TrimPrefix(path, "m/")
 	parts := strings.Split(path, "/")
 	for _, part := range parts {
 		if part == "" {

--- a/pkg/keys/hd/hdwallet_test.go
+++ b/pkg/keys/hd/hdwallet_test.go
@@ -212,6 +212,24 @@ func TestNewParamsFromPath_Valid(t *testing.T) {
 			wantChange:   false,
 			wantAddrIdx:  0,
 		},
+		{
+			name:         "TRON standard path with m/ prefix",
+			path:         "m/44'/195'/0'/0/0",
+			wantPurpose:  44,
+			wantCoinType: tronCoinType,
+			wantAccount:  0,
+			wantChange:   false,
+			wantAddrIdx:  0,
+		},
+		{
+			name:         "Ethereum with m/ prefix",
+			path:         "m/44'/60'/0'/0/0",
+			wantPurpose:  44,
+			wantCoinType: 60,
+			wantAccount:  0,
+			wantChange:   false,
+			wantAddrIdx:  0,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #246

`NewParamsFromPath` and `DerivePrivateKeyForPath` now accept the standard BIP44 path format with `m/` prefix (e.g., `m/44'/195'/0'/0/0`).

Every wallet and BIP44 documentation uses the `m/` prefix format. This change strips the optional `m/` prefix before parsing, maintaining backward compatibility with paths that omit it.

Changes:
- Strip `m/` prefix in `NewParamsFromPath` before splitting
- Strip `m/` prefix in `DerivePrivateKeyForPath` before splitting
- Add test cases for `m/` prefixed paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HD wallet paths now accept an optional "m/" prefix (e.g., m/44'/60'/0'/0/0), offering greater flexibility in path format acceptance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->