### PR TITLE
feat(client): add TriggerContractWithData / TriggerConstantContractWithData for pre-packed ABI data

### DIFF
--- a/pkg/client/contracts.go
+++ b/pkg/client/contracts.go
@@ -211,6 +211,87 @@ func (g *GrpcClient) triggerContract(ctx context.Context, ct *core.TriggerSmartC
 	return tx, err
 }
 
+// TriggerConstantContractWithData calls a constant contract method using
+// pre-packed ABI data, bypassing the JSON string → parse → pack pipeline.
+// This is useful when callers already have packed data from go-ethereum's
+// abi.Pack() or similar tooling.
+func (g *GrpcClient) TriggerConstantContractWithData(from, contractAddress string, data []byte) (*api.TransactionExtention, error) {
+	ctx, cancel := g.newContext()
+	defer cancel()
+	return g.TriggerConstantContractWithDataCtx(ctx, from, contractAddress, data)
+}
+
+// TriggerConstantContractWithDataCtx is the context-aware version of TriggerConstantContractWithData.
+func (g *GrpcClient) TriggerConstantContractWithDataCtx(ctx context.Context, from, contractAddress string, data []byte) (*api.TransactionExtention, error) {
+	ctx = g.withAPIKey(ctx)
+
+	var err error
+	fromDesc := address.HexToAddress("410000000000000000000000000000000000000000")
+	if len(from) > 0 {
+		fromDesc, err = address.Base58ToAddress(from)
+		if err != nil {
+			return nil, err
+		}
+	}
+	contractDesc, err := address.Base58ToAddress(contractAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	ct := &core.TriggerSmartContract{
+		OwnerAddress:    fromDesc.Bytes(),
+		ContractAddress: contractDesc.Bytes(),
+		Data:            data,
+	}
+
+	return g.triggerConstantContract(ctx, ct)
+}
+
+// TriggerContractWithData triggers a contract method using pre-packed ABI
+// data, bypassing the JSON string → parse → pack pipeline. This is useful
+// when callers already have packed data from go-ethereum's abi.Pack() or
+// similar tooling.
+func (g *GrpcClient) TriggerContractWithData(from, contractAddress string, data []byte,
+	feeLimit, tAmount int64, tTokenID string, tTokenAmount int64) (*api.TransactionExtention, error) {
+	ctx, cancel := g.newContext()
+	defer cancel()
+	return g.TriggerContractWithDataCtx(ctx, from, contractAddress, data, feeLimit, tAmount, tTokenID, tTokenAmount)
+}
+
+// TriggerContractWithDataCtx is the context-aware version of TriggerContractWithData.
+func (g *GrpcClient) TriggerContractWithDataCtx(ctx context.Context, from, contractAddress string, data []byte,
+	feeLimit, tAmount int64, tTokenID string, tTokenAmount int64) (*api.TransactionExtention, error) {
+	ctx = g.withAPIKey(ctx)
+
+	fromDesc, err := address.Base58ToAddress(from)
+	if err != nil {
+		return nil, err
+	}
+
+	contractDesc, err := address.Base58ToAddress(contractAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	ct := &core.TriggerSmartContract{
+		OwnerAddress:    fromDesc.Bytes(),
+		ContractAddress: contractDesc.Bytes(),
+		Data:            data,
+	}
+	if tAmount > 0 {
+		ct.CallValue = tAmount
+	}
+	if len(tTokenID) > 0 && tTokenAmount > 0 {
+		ct.CallTokenValue = tTokenAmount
+		ct.TokenId, err = strconv.ParseInt(tTokenID, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return g.triggerContract(ctx, ct, feeLimit)
+}
+
 // EstimateEnergy returns enery required
 func (g *GrpcClient) EstimateEnergy(from, contractAddress, method, jsonString string,
 	tAmount int64, tTokenID string, tTokenAmount int64) (*api.EstimateEnergyMessage, error) {

--- a/pkg/client/contracts_test.go
+++ b/pkg/client/contracts_test.go
@@ -182,6 +182,169 @@ func TestGetAccount(t *testing.T) {
 	assert.Equal(t, big.NewInt(1), result["frozen"])
 }
 
+func TestTriggerConstantContractWithData(t *testing.T) {
+	// Pre-packed ABI data for "balanceOf(address)" with a known address
+	packedData, _ := hex.DecodeString(
+		"70a08231" + // function selector: balanceOf(address)
+			"0000000000000000000000009df085719e7e0bd5bf4fd1b2a6aed6afd2b8416d",
+	)
+	expectedResult, _ := hex.DecodeString(
+		"0000000000000000000000000000000000000000000000000000000005f5e100", // 100000000
+	)
+
+	var capturedData []byte
+	mock := &mockWalletServer{
+		TriggerConstantContractFunc: func(_ context.Context, ct *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			capturedData = ct.Data
+			return &api.TransactionExtention{
+				Result: &api.Return{
+					Result: true,
+					Code:   api.Return_SUCCESS,
+				},
+				ConstantResult: [][]byte{expectedResult},
+			}, nil
+		},
+	}
+
+	c := newMockClient(t, mock)
+
+	tx, err := c.TriggerConstantContractWithData(
+		"",
+		"TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
+		packedData,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, api.Return_SUCCESS, tx.Result.Code)
+	assert.Equal(t, packedData, capturedData)
+	assert.Equal(t, expectedResult, tx.ConstantResult[0])
+}
+
+func TestTriggerConstantContractWithData_WithFrom(t *testing.T) {
+	packedData, _ := hex.DecodeString("70a08231" +
+		"0000000000000000000000009df085719e7e0bd5bf4fd1b2a6aed6afd2b8416d")
+
+	mock := &mockWalletServer{
+		TriggerConstantContractFunc: func(_ context.Context, ct *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			// Verify owner address is set (not zero address)
+			assert.NotEmpty(t, ct.OwnerAddress)
+			return &api.TransactionExtention{
+				Result: &api.Return{
+					Result: true,
+					Code:   api.Return_SUCCESS,
+				},
+				ConstantResult: [][]byte{{}},
+			}, nil
+		},
+	}
+
+	c := newMockClient(t, mock)
+
+	tx, err := c.TriggerConstantContractWithData(
+		"TTGhREx2pDSxFX555NWz1YwGpiBVPvQA7e",
+		"TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
+		packedData,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, api.Return_SUCCESS, tx.Result.Code)
+}
+
+func TestTriggerContractWithData(t *testing.T) {
+	// Pre-packed ABI data for "transfer(address,uint256)"
+	packedData, _ := hex.DecodeString(
+		"a9059cbb" + // function selector: transfer(address,uint256)
+			"0000000000000000000000009df085719e7e0bd5bf4fd1b2a6aed6afd2b8416d" +
+			"00000000000000000000000000000000000000000000000000000000000f4240",
+	)
+
+	var capturedContract *core.TriggerSmartContract
+	mock := &mockWalletServer{
+		TriggerContractFunc: func(_ context.Context, ct *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			capturedContract = ct
+			return &api.TransactionExtention{
+				Result: &api.Return{
+					Result: true,
+					Code:   api.Return_SUCCESS,
+				},
+				Transaction: &core.Transaction{
+					RawData: &core.TransactionRaw{},
+				},
+			}, nil
+		},
+	}
+
+	c := newMockClient(t, mock)
+
+	tx, err := c.TriggerContractWithData(
+		"TTGhREx2pDSxFX555NWz1YwGpiBVPvQA7e",
+		"TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
+		packedData,
+		100000000, // feeLimit
+		0, "", 0,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, api.Return_SUCCESS, tx.Result.Code)
+	assert.Equal(t, packedData, capturedContract.Data)
+	assert.Equal(t, int64(0), capturedContract.CallValue)
+}
+
+func TestTriggerContractWithData_WithCallValue(t *testing.T) {
+	packedData, _ := hex.DecodeString("a9059cbb" +
+		"0000000000000000000000009df085719e7e0bd5bf4fd1b2a6aed6afd2b8416d" +
+		"00000000000000000000000000000000000000000000000000000000000f4240")
+
+	var capturedContract *core.TriggerSmartContract
+	mock := &mockWalletServer{
+		TriggerContractFunc: func(_ context.Context, ct *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			capturedContract = ct
+			return &api.TransactionExtention{
+				Result: &api.Return{
+					Result: true,
+					Code:   api.Return_SUCCESS,
+				},
+				Transaction: &core.Transaction{
+					RawData: &core.TransactionRaw{},
+				},
+			}, nil
+		},
+	}
+
+	c := newMockClient(t, mock)
+
+	tx, err := c.TriggerContractWithData(
+		"TTGhREx2pDSxFX555NWz1YwGpiBVPvQA7e",
+		"TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
+		packedData,
+		100000000,
+		5000000,   // callValue
+		"1000001", // tokenID
+		2000000,   // tokenAmount
+	)
+	require.NoError(t, err)
+	assert.Equal(t, api.Return_SUCCESS, tx.Result.Code)
+	assert.Equal(t, int64(5000000), capturedContract.CallValue)
+	assert.Equal(t, int64(2000000), capturedContract.CallTokenValue)
+	assert.Equal(t, int64(1000001), capturedContract.TokenId)
+}
+
+func TestTriggerContractWithData_InvalidAddress(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+
+	_, err := c.TriggerContractWithData(
+		"invalid-address",
+		"TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
+		[]byte{0x01},
+		0, 0, "", 0,
+	)
+	require.Error(t, err)
+
+	_, err = c.TriggerConstantContractWithData(
+		"",
+		"invalid-address",
+		[]byte{0x01},
+	)
+	require.Error(t, err)
+}
+
 func TestGetAccountMigrationContract(t *testing.T) {
 	// frozenAmount returns a single uint256
 	frozenResult, _ := hex.DecodeString("0000000000000000000000000000000000000000000000000000000005f5e100") // 100000000


### PR DESCRIPTION
## Summary

- Add `TriggerContractWithData` / `TriggerContractWithDataCtx` and `TriggerConstantContractWithData` / `TriggerConstantContractWithDataCtx` methods that accept raw `[]byte` ABI data directly
- Bypasses the JSON string → `abi.LoadFromJSON` → `abi.Pack` pipeline for users who already have packed data from go-ethereum's `abi.Pack()` or similar tooling
- Reuses existing internal `triggerContract()` and `triggerConstantContract()` helpers

## Test plan

- [x] Unit tests for `TriggerConstantContractWithData` (empty and non-empty `from`)
- [x] Unit tests for `TriggerContractWithData` (basic, with callValue/token params)
- [x] Invalid address error handling test
- [x] All existing tests pass
- [x] Linter clean (0 issues)

Closes #240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added contract invocation methods that accept pre-packed ABI data, enabling direct smart contract triggering without intermediate encoding steps.
  * Supports both constant and regular contract calls with optional fee and token parameters.

* **Tests**
  * Added comprehensive test coverage for new contract data invocation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->