### PR TITLE
feat(cmd): add tronctl upgrade command for self-updating

### DIFF
--- a/cmd/subcommands/upgrade.go
+++ b/cmd/subcommands/upgrade.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -110,6 +111,7 @@ func runInstallScript(version string) error {
 		return fmt.Errorf("failed to start download: %w", err)
 	}
 	if err := sh.Start(); err != nil {
+		_ = curl.Process.Kill()
 		_ = curl.Wait()
 		return fmt.Errorf("failed to start installer: %w", err)
 	}
@@ -142,10 +144,12 @@ func detectManagedInstall() (string, bool) {
 		return "this binary was installed via Homebrew; upgrade with:\n  brew upgrade tronctl", true
 	}
 
-	// go install: check build info for a real module version
+	// go install: check build info for a real module version.
+	// goreleaser sets VersionWrapDump via ldflags with a "v" prefix (e.g. "v0.25.1-abc1234"),
+	// while go install builds leave it empty — so an absent or non-v-prefixed value means
+	// the binary was installed via go install.
 	info, ok := debug.ReadBuildInfo()
 	if ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
-		// goreleaser builds set VersionWrapDump via ldflags with a v-prefix
 		if VersionWrapDump == "" || !strings.HasPrefix(strings.Split(VersionWrapDump, "-")[0], "v") {
 			return "this binary was installed via `go install`; upgrade with:\n  go install github.com/fbsobreira/gotron-sdk/cmd/tronctl@latest", true
 		}
@@ -174,13 +178,12 @@ func fetchRelease(version string) (*GitHubRelease, error) {
 		url = versionLink
 	}
 
-	resp, err := http.Get(url) //nolint:gosec // URL is constructed from constants
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(url) //nolint:gosec // URL is constructed from constants
 	if err != nil {
 		return nil, err
 	}
-	if resp != nil {
-		defer func() { _ = resp.Body.Close() }()
-	}
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		if version != "" {


### PR DESCRIPTION
## Summary

- Add `tronctl upgrade` command that downloads and installs the latest release by delegating to the project's `install.sh` script
- Support `--check` flag to only check for available updates without installing
- Support `--version <tag>` flag to upgrade/downgrade to a specific release
- Detect Homebrew and `go install` builds, redirecting users to the appropriate upgrade method (`brew upgrade` / `go install ...@latest`)

## Test plan

- [x] Build with a fake old version: `go build -ldflags "-X main.version=v0.0.1 -X main.commit=abc1234" -o ./tronctl ./cmd/tronctl`
- [x] Run `./tronctl upgrade --check` — should show update available
- [x] Run `./tronctl upgrade` — should download and install via install.sh
- [x] Run `./tronctl upgrade --version v0.25.1` — should install specific version
- [x] Verify Homebrew detection by symlinking binary under a `/Cellar/` path
- [x] Verify `go install` detection by installing via `go install`

Closes #244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added upgrade command with `--check` flag to verify available updates without installing
  * Added `--version` flag to upgrade to a specific release version
  * Automatic detection and guidance for managed installations
  * Progress logging with status indicators throughout the upgrade process
  * Validation of required dependencies before proceeding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->