### PR TITLE
feat(address): add BytesToAddress and EthAddressToAddress utilities

### DIFF
--- a/pkg/address/address.go
+++ b/pkg/address/address.go
@@ -116,8 +116,8 @@ func BTCECPrivkeyToAddress(p *btcec.PrivateKey) Address {
 
 // BytesToAddress converts raw bytes to a TRON Address.
 // For 20-byte input, the TRON mainnet prefix (0x41) is prepended.
-// For 21-byte input, the bytes are used as-is.
-// For any other length, the bytes are returned as-is without modification.
+// For 21-byte input, the bytes are copied as-is.
+// For any other length, a copy of the input bytes is returned without validation.
 func BytesToAddress(b []byte) Address {
 	switch len(b) {
 	case AddressLength - 1:

--- a/pkg/address/address_test.go
+++ b/pkg/address/address_test.go
@@ -651,14 +651,6 @@ func TestBytesToAddress(t *testing.T) {
 				assert.Equal(t, Address([]byte{0x01, 0x02}), addr)
 			},
 		},
-		{
-			name:  "input does not share underlying array",
-			input: []byte{0x41, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13},
-			check: func(t *testing.T, addr Address) {
-				// Modify original should not affect the address
-				assert.Len(t, addr, AddressLength)
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -667,6 +659,17 @@ func TestBytesToAddress(t *testing.T) {
 			tt.check(t, addr)
 		})
 	}
+
+	t.Run("21-byte input is copied", func(t *testing.T) {
+		original, err := Base58ToAddress(testBase58Addr1)
+		require.NoError(t, err)
+
+		input := append([]byte(nil), original.Bytes()...)
+		addr := BytesToAddress(input)
+		input[0] ^= 0xff
+
+		assert.Equal(t, original.Bytes(), addr.Bytes())
+	})
 }
 
 func TestEthAddressToAddress(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `BytesToAddress` for converting raw `[]byte` to TRON addresses (prepends `0x41` for 20-byte input, copies as-is otherwise)
- Add `EthAddressToAddress` for strict 20-byte Ethereum → TRON address conversion with error handling
- Comprehensive tests covering valid inputs, edge cases, error paths, and round-trip consistency

## Test plan

- [x] All existing `pkg/address` tests pass
- [x] New tests cover: 20-byte, 21-byte, empty, nil, short, wrong-length inputs
- [x] Round-trip tests verify consistency with `PubkeyToAddress` and `Base58ToAddress`
- [x] `make goimports` and `make lint` pass with 0 issues

Closes #245

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added address conversion support to handle raw byte inputs and translate Ethereum-style addresses into TRON-style addresses, including proper handling of 20- and 21-byte formats and validation/error reporting.

* **Tests**
  * Added comprehensive tests covering conversion edge cases, invalid inputs, round-trip consistency, and cross-format compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->