### PR TITLE
fix(keystore): remove errant zeroKey in SignTx that breaks multi-sign

### DIFF
--- a/pkg/keystore/keystore.go
+++ b/pkg/keystore/keystore.go
@@ -301,8 +301,6 @@ func (ks *KeyStore) SignTx(a Account, tx *core.Transaction) (*core.Transaction, 
 	if !found {
 		return nil, ErrLocked
 	}
-	defer zeroKey(unlockedKey.PrivateKey)
-
 	rawData, err := proto.Marshal(tx.GetRawData())
 	if err != nil {
 		return nil, err
@@ -316,7 +314,6 @@ func (ks *KeyStore) SignTx(a Account, tx *core.Transaction) (*core.Transaction, 
 		return nil, err
 	}
 	tx.Signature = append(tx.Signature, signature)
-	_ = unlockedKey
 	return tx, nil
 }
 

--- a/pkg/keystore/keystore_test.go
+++ b/pkg/keystore/keystore_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/fbsobreira/gotron-sdk/pkg/address"
 	"github.com/fbsobreira/gotron-sdk/pkg/keystore"
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -299,6 +300,111 @@ func TestSignHashWithPassphrase(t *testing.T) {
 
 		_, err = ks.SignHashWithPassphrase(acc, "pass", make([]byte, 33))
 		require.Error(t, err)
+	})
+}
+
+// ---------- SignTx ----------
+
+// dummyTx returns a minimal Transaction suitable for signing tests.
+func dummyTx(t *testing.T) *core.Transaction {
+	t.Helper()
+	return &core.Transaction{
+		RawData: &core.TransactionRaw{
+			RefBlockBytes: []byte{0x00, 0x01},
+			RefBlockHash:  make([]byte, 8),
+			Expiration:    1_000_000,
+		},
+	}
+}
+
+func TestSignTx(t *testing.T) {
+	t.Run("sign two transactions sequentially with same unlocked account", func(t *testing.T) {
+		ks := newTestKeyStore(t)
+		acc, err := ks.NewAccount("pass")
+		require.NoError(t, err)
+		require.NoError(t, ks.Unlock(acc, "pass"))
+
+		tx1 := dummyTx(t)
+		signed1, err := ks.SignTx(acc, tx1)
+		require.NoError(t, err)
+		require.Len(t, signed1.Signature, 1, "first sign must produce a signature")
+
+		tx2 := dummyTx(t)
+		signed2, err := ks.SignTx(acc, tx2)
+		require.NoError(t, err)
+		require.Len(t, signed2.Signature, 1, "second sign must also succeed")
+	})
+
+	t.Run("sign then lock then sign returns ErrLocked", func(t *testing.T) {
+		ks := newTestKeyStore(t)
+		acc, err := ks.NewAccount("pass")
+		require.NoError(t, err)
+		require.NoError(t, ks.Unlock(acc, "pass"))
+
+		tx1 := dummyTx(t)
+		_, err = ks.SignTx(acc, tx1)
+		require.NoError(t, err)
+
+		require.NoError(t, ks.Lock(acc.Address))
+
+		tx2 := dummyTx(t)
+		_, err = ks.SignTx(acc, tx2)
+		assert.ErrorIs(t, err, keystore.ErrLocked, "signing after lock must fail")
+	})
+
+	t.Run("sign fails after TimedUnlock expiry", func(t *testing.T) {
+		ks := newTestKeyStore(t)
+		acc, err := ks.NewAccount("pass")
+		require.NoError(t, err)
+		require.NoError(t, ks.TimedUnlock(acc, "pass", 60*time.Millisecond))
+
+		tx1 := dummyTx(t)
+		_, err = ks.SignTx(acc, tx1)
+		require.NoError(t, err, "sign should succeed while timed unlock is active")
+
+		// Wait for expiry.
+		time.Sleep(200 * time.Millisecond)
+
+		tx2 := dummyTx(t)
+		_, err = ks.SignTx(acc, tx2)
+		assert.ErrorIs(t, err, keystore.ErrLocked, "signing after timed unlock expiry must fail")
+	})
+
+	t.Run("sign when locked returns ErrLocked", func(t *testing.T) {
+		ks := newTestKeyStore(t)
+		acc, err := ks.NewAccount("pass")
+		require.NoError(t, err)
+
+		tx := dummyTx(t)
+		_, err = ks.SignTx(acc, tx)
+		assert.ErrorIs(t, err, keystore.ErrLocked)
+	})
+}
+
+// ---------- SignTxWithPassphrase ----------
+
+func TestSignTxWithPassphrase(t *testing.T) {
+	t.Run("sign multiple transactions with passphrase", func(t *testing.T) {
+		ks := newTestKeyStore(t)
+		acc, err := ks.NewAccount("pass")
+		require.NoError(t, err)
+
+		for i := 0; i < 3; i++ {
+			tx := dummyTx(t)
+			signed, err := ks.SignTxWithPassphrase(acc, "pass", tx)
+			require.NoError(t, err, "SignTxWithPassphrase call %d must succeed", i+1)
+			require.Len(t, signed.Signature, 1)
+		}
+	})
+
+	t.Run("sign with wrong passphrase fails", func(t *testing.T) {
+		ks := newTestKeyStore(t)
+		acc, err := ks.NewAccount("correct")
+		require.NoError(t, err)
+
+		tx := dummyTx(t)
+		_, err = ks.SignTxWithPassphrase(acc, "wrong", tx)
+		assert.Error(t, err)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Remove `defer zeroKey(unlockedKey.PrivateKey)` from `SignTx()` which was zeroing the private key in the unlocked map after every sign operation, breaking subsequent `SignTx()` calls with the same unlocked account
- The key lifecycle is already correctly managed by `Lock()`/`expire()` — no zeroing gap is introduced
- Add comprehensive `SignTx` and `SignTxWithPassphrase` tests covering multi-sign, lock, timed unlock expiry, and passphrase-based signing

Closes #247

## Test plan

- [x] `TestSignTx/sign_two_transactions_sequentially_with_same_unlocked_account` — primary regression test
- [x] `TestSignTx/sign_then_lock_then_sign_returns_ErrLocked`
- [x] `TestSignTx/sign_fails_after_TimedUnlock_expiry`
- [x] `TestSignTx/sign_when_locked_returns_ErrLocked`
- [x] `TestSignTxWithPassphrase/sign_multiple_transactions_with_passphrase`
- [x] `TestSignTxWithPassphrase/sign_with_wrong_passphrase_fails`
- [x] Full keystore test suite passes
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Modified private key handling during transaction signing operations.

* **Tests**
  * Added comprehensive test coverage for transaction signing, including scenarios for locked and unlocked accounts, passphrase-based authentication, and timer-based access restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->