### PR TITLE
feat(client): add callValue support to TriggerConstantContract (#241)

### DIFF
--- a/pkg/client/contracts.go
+++ b/pkg/client/contracts.go
@@ -29,17 +29,23 @@ func WithCallValue(value int64) ConstantCallOption {
 }
 
 // WithTokenValue sets the TRC10 token ID and amount on a constant contract call.
-func WithTokenValue(tokenID string, amount int64) ConstantCallOption {
-	return func(ct *core.TriggerSmartContract) {
-		if id, err := strconv.ParseInt(tokenID, 10, 64); err == nil {
-			ct.TokenId = id
-			ct.CallTokenValue = amount
-		}
+// It returns an error if tokenID is not a valid integer.
+func WithTokenValue(tokenID string, amount int64) (ConstantCallOption, error) {
+	id, err := strconv.ParseInt(tokenID, 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid token ID %q: %w", tokenID, err)
 	}
+	return func(ct *core.TriggerSmartContract) {
+		ct.TokenId = id
+		ct.CallTokenValue = amount
+	}, nil
 }
 
 func applyConstantCallOptions(ct *core.TriggerSmartContract, opts []ConstantCallOption) {
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		opt(ct)
 	}
 }

--- a/pkg/client/contracts_test.go
+++ b/pkg/client/contracts_test.go
@@ -391,17 +391,26 @@ func TestTriggerConstantContract_WithTokenValue(t *testing.T) {
 
 	c := newMockClient(t, mock)
 
+	opt, err := client.WithTokenValue("1000001", 2_000_000)
+	require.NoError(t, err)
+
 	tx, err := c.TriggerConstantContract(
 		"TTGhREx2pDSxFX555NWz1YwGpiBVPvQA7e",
 		"TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
 		"deposit(uint256)",
 		`[{"uint256": "500"}]`,
-		client.WithTokenValue("1000001", 2_000_000),
+		opt,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, api.Return_SUCCESS, tx.Result.Code)
 	assert.Equal(t, int64(1000001), capturedContract.TokenId)
 	assert.Equal(t, int64(2_000_000), capturedContract.CallTokenValue)
+}
+
+func TestWithTokenValue_InvalidTokenID(t *testing.T) {
+	_, err := client.WithTokenValue("not-a-number", 1000)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid token ID")
 }
 
 func TestTriggerConstantContract_WithMultipleOptions(t *testing.T) {
@@ -421,13 +430,16 @@ func TestTriggerConstantContract_WithMultipleOptions(t *testing.T) {
 
 	c := newMockClient(t, mock)
 
+	tokenOpt, err := client.WithTokenValue("1000001", 3_000_000)
+	require.NoError(t, err)
+
 	tx, err := c.TriggerConstantContract(
 		"TTGhREx2pDSxFX555NWz1YwGpiBVPvQA7e",
 		"TVSvjZdyDSNocHm7dP3jvCmMNsCnMTPa5W",
 		"swap(uint256)",
 		`[{"uint256": "1000"}]`,
 		client.WithCallValue(5_000_000),
-		client.WithTokenValue("1000001", 3_000_000),
+		tokenOpt,
 	)
 	require.NoError(t, err)
 	assert.Equal(t, api.Return_SUCCESS, tx.Result.Code)


### PR DESCRIPTION
## Summary

- Add variadic `ConstantCallOption` functional options (`WithCallValue`, `WithTokenValue`) to `TriggerConstantContract`, `TriggerConstantContractCtx`, `TriggerConstantContractWithData`, and `TriggerConstantContractWithDataCtx`
- Enables accurate simulation of payable functions that depend on `msg.value` (DEX swaps, payable mints, deposit functions)
- Non-breaking change — existing callers are unaffected

## Usage

```go
// Existing code still works (no breaking change)
client.TriggerConstantContract(from, contract, "balanceOf", params)

// Payable simulation with callValue
client.TriggerConstantContract(from, contract, "swap", params, WithCallValue(1_000_000))

// With TRC10 token value
client.TriggerConstantContract(from, contract, "deposit", params, WithTokenValue("1000001", 2_000_000))
```

## Test plan

- [x] `TestTriggerConstantContract_WithCallValue` — verifies CallValue is set on the proto
- [x] `TestTriggerConstantContract_WithTokenValue` — verifies TokenId and CallTokenValue are set
- [x] `TestTriggerConstantContract_WithMultipleOptions` — verifies multiple options compose correctly
- [x] `TestTriggerConstantContractWithData_WithCallValue` — verifies WithData variant works with options
- [x] All existing tests pass (backward compatibility confirmed)
- [x] `make lint` — 0 issues
- [x] `make goimports` — clean

Closes #241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smart contract calls now support optional parameters to set call value and token value, and to include binary data, allowing finer control over read-only contract queries and payloadled constant calls.

* **Tests**
  * Added extensive unit tests covering combinations of call value, token value, invalid token handling, and data payload scenarios to ensure correct propagation and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->