### PR TITLE
feat(client): add WithEstimate() option to TRC20 methods (#242)

### DIFF
--- a/pkg/client/trc20.go
+++ b/pkg/client/trc20.go
@@ -25,6 +25,9 @@ type trc20Config struct {
 func applyTRC20Options(opts []TRC20Option) trc20Config {
 	var cfg trc20Config
 	for _, o := range opts {
+		if o == nil {
+			continue
+		}
 		o(&cfg)
 	}
 	return cfg

--- a/pkg/client/trc20_test.go
+++ b/pkg/client/trc20_test.go
@@ -320,6 +320,10 @@ func TestParseTRC20StringProperty(t *testing.T) {
 func estimateMock(t *testing.T, wantSigPrefix string) *mockWalletServer {
 	t.Helper()
 	return &mockWalletServer{
+		TriggerContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			t.Fatal("unexpected TriggerContract call: WithEstimate() must use TriggerConstantContract")
+			return nil, nil
+		},
 		TriggerConstantContractFunc: func(_ context.Context, in *core.TriggerSmartContract) (*api.TransactionExtention, error) {
 			dataHex := hex.EncodeToString(in.Data)
 			assert.True(t, len(dataHex) >= 8, "data too short")


### PR DESCRIPTION
## Summary

- Add `TRC20Option` variadic option type and `WithEstimate()` constructor
- Update `TRC20Send`, `TRC20Approve`, `TRC20TransferFrom` (and `Ctx` variants) to accept `...TRC20Option`
- When `WithEstimate()` is passed, internally use `TriggerConstantContract` for dry-run energy estimation instead of `TriggerContract`

Non-breaking change — existing callers are unaffected. Follows the same variadic option pattern as #241 (`WithCallValue`).

Closes #242

## Test plan

- [x] Added `TestTRC20Send_WithEstimate` — verifies Send routes to `TriggerConstantContract`
- [x] Added `TestTRC20Approve_WithEstimate` — verifies Approve routes to `TriggerConstantContract`
- [x] Added `TestTRC20TransferFrom_WithEstimate` — verifies TransferFrom routes to `TriggerConstantContract`
- [x] All existing tests pass (backward compatibility confirmed)
- [x] `make goimports`, `make lint`, `make test` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TRC20 transaction methods now support an optional dry-run estimation mode, allowing transactions to be simulated before being submitted.

* **Tests**
  * Added test coverage validating the TRC20 dry-run estimation path and ensuring simulated results are returned as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->