### PR TITLE
fix(common): strip only leading 0x prefix in HexStringToBytes

### DIFF
--- a/pkg/common/hexutils.go
+++ b/pkg/common/hexutils.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"encoding/hex"
-	"strings"
 )
 
 var (
@@ -29,8 +28,10 @@ func HexStringToBytes(input string) ([]byte, error) {
 	if len(input) == 0 {
 		return nil, EmptyString
 	}
-
-	return hex.DecodeString(strings.ReplaceAll(input, "0x", ""))
+	if Has0xPrefix(input) {
+		input = input[2:]
+	}
+	return hex.DecodeString(input)
 }
 
 // ToHex returns the hex representation of b, prefixed with '0x'.

--- a/pkg/common/hexutils_test.go
+++ b/pkg/common/hexutils_test.go
@@ -109,6 +109,18 @@ func TestHexStringToBytes(t *testing.T) {
 			want:    []byte{0x00, 0x00},
 			wantErr: false,
 		},
+		{
+			name:    "uppercase 0X prefix",
+			input:   "0Xdeadbeef",
+			want:    []byte{0xde, 0xad, 0xbe, 0xef},
+			wantErr: false,
+		},
+		{
+			name:    "embedded 0x not stripped",
+			input:   "dead0xbeef",
+			want:    nil,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Replace `strings.ReplaceAll(input, "0x", "")` with `Has0xPrefix` check + slice to strip only the leading `0x`/`0X` prefix instead of all occurrences
- Remove unused `strings` import
- Add test cases for uppercase `0X` prefix and embedded `0x` (which now correctly fails)

Closes #262

## Test plan

- [x] All existing `TestHexStringToBytes` cases pass
- [x] New test: uppercase `0X` prefix is correctly stripped
- [x] New test: embedded `0x` in input is not stripped (returns error)
- [x] Full test suite passes (`make test`)
- [x] `make goimports` and `make lint` pass clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hex string parsing to properly handle uppercase `0X` prefixes and strip only one leading prefix occurrence instead of removing all instances.

* **Tests**
  * Added test coverage for uppercase prefix handling and validation of embedded prefix rejection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->