### PR TITLE
fix(mnemonic): return error from Generate() instead of silently discarding

### DIFF
--- a/cmd/subcommands/keys.go
+++ b/cmd/subcommands/keys.go
@@ -103,7 +103,11 @@ func keysSub() []*cobra.Command {
 		Use:   "mnemonic",
 		Short: "Compute the bip39 mnemonic for some input entropy",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println(mnemonic.Generate())
+			m, err := mnemonic.Generate()
+			if err != nil {
+				return err
+			}
+			fmt.Println(m)
 			return nil
 		},
 	}

--- a/pkg/account/creation.go
+++ b/pkg/account/creation.go
@@ -2,6 +2,8 @@
 package account
 
 import (
+	"fmt"
+
 	"github.com/fbsobreira/gotron-sdk/pkg/keys"
 	"github.com/fbsobreira/gotron-sdk/pkg/mnemonic"
 	"github.com/fbsobreira/gotron-sdk/pkg/store"
@@ -34,7 +36,11 @@ func CreateNewLocalAccount(candidate *Creation) error {
 	ks := store.FromAccountName(candidate.Name)
 	defer ks.Close()
 	if candidate.Mnemonic == "" {
-		candidate.Mnemonic = mnemonic.Generate()
+		m, err := mnemonic.Generate()
+		if err != nil {
+			return fmt.Errorf("generate mnemonic: %w", err)
+		}
+		candidate.Mnemonic = m
 	}
 	// Hardcoded index of 0 for brandnew account.
 	private, _ := keys.FromMnemonicSeedAndPassphrase(candidate.Mnemonic, candidate.MnemonicPassphrase, 0)

--- a/pkg/account/import.go
+++ b/pkg/account/import.go
@@ -19,9 +19,17 @@ func ImportFromPrivateKey(privateKey, name, passphrase string) (string, error) {
 	privateKey = strings.TrimPrefix(privateKey, "0x")
 
 	if name == "" {
-		name = generateName() + "-imported"
+		base, err := generateName()
+		if err != nil {
+			return "", fmt.Errorf("generate account name: %w", err)
+		}
+		name = base + "-imported"
 		for store.DoesNamedAccountExist(name) {
-			name = generateName() + "-imported"
+			base, err = generateName()
+			if err != nil {
+				return "", fmt.Errorf("generate account name: %w", err)
+			}
+			name = base + "-imported"
 		}
 	} else if store.DoesNamedAccountExist(name) {
 		return "", fmt.Errorf("account %s already exists", name)
@@ -39,8 +47,12 @@ func ImportFromPrivateKey(privateKey, name, passphrase string) (string, error) {
 	return name, err
 }
 
-func generateName() string {
-	words := strings.Split(mnemonic.Generate(), " ")
+func generateName() (string, error) {
+	m, err := mnemonic.Generate()
+	if err != nil {
+		return "", err
+	}
+	words := strings.Split(m, " ")
 	existingAccounts := mapset.NewSet()
 	for a := range store.LocalAccounts() {
 		existingAccounts.Add(a)
@@ -49,12 +61,16 @@ func generateName() string {
 	i := 0
 	for {
 		if i >= len(words) {
-			words = strings.Split(mnemonic.Generate(), " ")
+			m, err = mnemonic.Generate()
+			if err != nil {
+				return "", err
+			}
+			words = strings.Split(m, " ")
 			i = 0
 		}
 		candidate := words[i]
 		if !existingAccounts.Contains(candidate) {
-			return candidate
+			return candidate, nil
 		}
 		i++
 	}
@@ -103,9 +119,17 @@ func ImportKeyStore(keyPath, name, passphrase string) (string, error) {
 		return "", readError
 	}
 	if name == "" {
-		name = generateName() + "-imported"
+		base, err := generateName()
+		if err != nil {
+			return "", fmt.Errorf("generate account name: %w", err)
+		}
+		name = base + "-imported"
 		for store.DoesNamedAccountExist(name) {
-			name = generateName() + "-imported"
+			base, err = generateName()
+			if err != nil {
+				return "", fmt.Errorf("generate account name: %w", err)
+			}
+			name = base + "-imported"
 		}
 	} else if store.DoesNamedAccountExist(name) {
 		return "", fmt.Errorf("account %s already exists", name)

--- a/pkg/mnemonic/mnemonic.go
+++ b/pkg/mnemonic/mnemonic.go
@@ -3,6 +3,7 @@ package mnemonic
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/fbsobreira/go-bip39"
 )
@@ -11,8 +12,14 @@ import (
 var ErrInvalidMnemonic = errors.New("invalid mnemonic given")
 
 // Generate returns a new random 24-word BIP39 mnemonic phrase.
-func Generate() string {
-	entropy, _ := bip39.NewEntropy(256)
-	mnemonic, _ := bip39.NewMnemonic(entropy)
-	return mnemonic
+func Generate() (string, error) {
+	entropy, err := bip39.NewEntropy(256)
+	if err != nil {
+		return "", fmt.Errorf("generate entropy: %w", err)
+	}
+	mnemonic, err := bip39.NewMnemonic(entropy)
+	if err != nil {
+		return "", fmt.Errorf("generate mnemonic: %w", err)
+	}
+	return mnemonic, nil
 }

--- a/pkg/mnemonic/mnemonic_test.go
+++ b/pkg/mnemonic/mnemonic_test.go
@@ -11,19 +11,23 @@ import (
 )
 
 func TestGenerate_WordCount(t *testing.T) {
-	m := mnemonic.Generate()
+	m, err := mnemonic.Generate()
+	require.NoError(t, err)
 	words := strings.Fields(m)
 	assert.Len(t, words, 24, "mnemonic should have 24 words")
 }
 
 func TestGenerate_ValidBIP39(t *testing.T) {
-	m := mnemonic.Generate()
+	m, err := mnemonic.Generate()
+	require.NoError(t, err)
 	assert.True(t, bip39.IsMnemonicValid(m), "generated mnemonic should be valid BIP39")
 }
 
 func TestGenerate_RepeatedCallsRemainValid(t *testing.T) {
-	m1 := mnemonic.Generate()
-	m2 := mnemonic.Generate()
+	m1, err := mnemonic.Generate()
+	require.NoError(t, err)
+	m2, err := mnemonic.Generate()
+	require.NoError(t, err)
 	require.NotEmpty(t, m1)
 	require.NotEmpty(t, m2)
 	assert.True(t, bip39.IsMnemonicValid(m1))
@@ -31,7 +35,8 @@ func TestGenerate_RepeatedCallsRemainValid(t *testing.T) {
 }
 
 func TestGenerate_ProducesValidSeed(t *testing.T) {
-	m := mnemonic.Generate()
+	m, err := mnemonic.Generate()
+	require.NoError(t, err)
 	seed, err := bip39.NewSeedWithErrorChecking(m, "")
 	require.NoError(t, err)
 	assert.Len(t, seed, 64, "BIP39 seed should be 64 bytes")


### PR DESCRIPTION
## Summary

- Change `mnemonic.Generate()` signature from `string` to `(string, error)`
- Propagate errors from `bip39.NewEntropy` and `bip39.NewMnemonic` instead of silently discarding them
- Update all callers to handle the new return type

### Files changed

| File | Change |
|------|--------|
| `pkg/mnemonic/mnemonic.go` | New `(string, error)` signature with error propagation |
| `pkg/account/creation.go` | `CreateNewLocalAccount` handles Generate error |
| `pkg/account/import.go` | `generateName()` returns `(string, error)`; both `ImportFromPrivateKey` and `ImportKeyStore` updated |
| `cmd/subcommands/keys.go` | Mnemonic command handles Generate error |
| `pkg/mnemonic/mnemonic_test.go` | All tests use `require.NoError` for the error return |

Closes #263

## Test plan

- [x] `make goimports` — passes
- [x] `make lint` — 0 issues
- [x] `make test` — all packages pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for mnemonic generation to detect and report failures gracefully instead of proceeding silently when generation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->