### PR TITLE
fix(ledger): return proper error and signature in SignTx

### DIFF
--- a/pkg/ledger/hw_wallet.go
+++ b/pkg/ledger/hw_wallet.go
@@ -78,13 +78,8 @@ func SignTx(tx []byte) ([]byte, error) {
 
 	if len(pubkey) == 0 || pubkey[0] != 4 {
 		log.Println("invalid public key")
-		return nil, err
+		return nil, fmt.Errorf("invalid public key")
 	}
 
-	//pubBytes := crypto.Keccak256(pubkey[1:65])[12:]
-	//signerAddr, _ := address.PubkeyToAddress(pubBytes)
-
-	// TODO:
-	//return sig, nil
-	return nil, nil
+	return sig[:], nil
 }


### PR DESCRIPTION
## Summary

- Return `fmt.Errorf("invalid public key")` instead of `nil` error when recovered public key is invalid
- Return the actual signature (`sig[:]`) instead of unconditionally returning `nil, nil`
- Remove dead commented-out code and TODO

Closes #264

## Test plan

- [x] `make goimports` passes clean
- [x] `make lint` passes with 0 issues
- [ ] Manual verification with Ledger hardware wallet (hardware-dependent package, no automated tests)

🔍 Found by CodeRabbit in #261

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hardware wallet transaction signing functionality to properly return valid signature bytes instead of empty/null values, ensuring transactions can be reliably signed and submitted.
  * Improved error handling and reporting for invalid public key scenarios during wallet operations, providing explicit and descriptive error messages instead of returning generic or unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->