### PR TITLE
fix: wire --details flag in account balance command

### DIFF
--- a/cmd/subcommands/account.go
+++ b/cmd/subcommands/account.go
@@ -36,6 +36,22 @@ func accountBalanceCmd() *cobra.Command {
 		Args:    cobra.ExactArgs(1),
 		PreRunE: validateAddress,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if balanceDetails {
+				acc, err := conn.GetAccountDetailed(addr.String())
+				if err != nil {
+					return err
+				}
+
+				if noPrettyOutput {
+					fmt.Println(acc)
+					return nil
+				}
+
+				asJSON, _ := json.Marshal(acc)
+				fmt.Println(common.JSONPrettyFormat(string(asJSON)))
+				return nil
+			}
+
 			acc, err := conn.GetAccount(addr.String())
 			if err != nil {
 				return err
@@ -63,7 +79,7 @@ func accountBalanceCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&balanceDetails, "details", false, "show detailed balance information")
+	cmd.Flags().BoolVar(&balanceDetails, "details", false, "show detailed account information")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary

Closes #273

The `account balance --details` flag was registered but never read — it was a no-op. This fix wires the `balanceDetails` variable into the command handler.

When `--details` is passed, the command now calls `GetAccountDetailed()` which returns the full `Account` struct including frozen balances, resources, votes, delegations, and withdrawable balance, instead of the compact 5-field summary.

## Test plan

- [x] `go build ./...` passes
- [x] `make goimports` clean
- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass
- [x] `account balance <addr>` still shows compact output (unchanged)
- [x] `account balance --details <addr>` shows full account details
- [x] Both modes respect `--noPretty`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the `account` command's `--details` flag to display comprehensive account information instead of just detailed balance data, providing users with complete account details in a single query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->