### PR TITLE
feat(contract): add fluent WithPermissionID, WithFeeLimit, WithCallValue, WithTokenValue

### DIFF
--- a/pkg/contract/builder.go
+++ b/pkg/contract/builder.go
@@ -125,30 +125,28 @@ func (c *ContractCall) Apply(opts ...Option) *ContractCall {
 // WithPermissionID sets the permission ID for multi-signature transactions.
 // Returns itself for chaining.
 func (c *ContractCall) WithPermissionID(id int32) *ContractCall {
-	c.cfg.permissionID = &id
-	return c
+	return c.Apply(WithPermissionID(id))
 }
 
 // WithFeeLimit sets the maximum TRX (in SUN) the caller is willing to spend
 // on energy for a state-changing contract call. Returns itself for chaining.
 func (c *ContractCall) WithFeeLimit(limit int64) *ContractCall {
-	c.cfg.feeLimit = limit
-	return c
+	return c.Apply(WithFeeLimit(limit))
 }
 
 // WithCallValue sets the TRX amount (in SUN) sent along with the call.
+// Used by both read-only Call and state-changing Build/Send.
 // Returns itself for chaining.
 func (c *ContractCall) WithCallValue(value int64) *ContractCall {
-	c.cfg.callValue = value
-	return c
+	return c.Apply(WithCallValue(value))
 }
 
 // WithTokenValue sets the TRC10 token ID and amount sent with the call.
+// Only affects state-changing operations (Build, Send, SendAndConfirm) and
+// EstimateEnergy; read-only Call does not forward token parameters.
 // Returns itself for chaining.
 func (c *ContractCall) WithTokenValue(tokenID string, amount int64) *ContractCall {
-	c.cfg.tokenID = tokenID
-	c.cfg.tokenAmount = amount
-	return c
+	return c.Apply(WithTokenValue(tokenID, amount))
 }
 
 // fromOrZero returns the configured from address, falling back to the zero

--- a/pkg/contract/builder_test.go
+++ b/pkg/contract/builder_test.go
@@ -15,16 +15,15 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 )
 
-// newDummyTxExt returns a minimal TransactionExtention for testing.
-func newDummyTxExt() *api.TransactionExtention {
+// newTestTxExt returns a minimal TransactionExtention for testing.
+func newTestTxExt() *api.TransactionExtention {
 	return &api.TransactionExtention{
 		Transaction: &core.Transaction{
 			RawData: &core.TransactionRaw{
 				Contract: []*core.Transaction_Contract{
 					{
-						Type:         core.Transaction_Contract_TriggerSmartContract,
-						Parameter:    &anypb.Any{Value: []byte("test")},
-						PermissionId: 0,
+						Type:      core.Transaction_Contract_TriggerSmartContract,
+						Parameter: &anypb.Any{Value: []byte("test")},
 					},
 				},
 			},
@@ -375,24 +374,6 @@ func (s *mockSigner) Sign(tx *core.Transaction) (*core.Transaction, error) {
 
 func (s *mockSigner) Address() address.Address { return nil }
 
-// newTestTxExt returns a minimal TransactionExtention for Send/SendAndConfirm tests.
-func newTestTxExt() *api.TransactionExtention {
-	return &api.TransactionExtention{
-		Transaction: &core.Transaction{
-			RawData: &core.TransactionRaw{
-				Contract: []*core.Transaction_Contract{
-					{
-						Type:      core.Transaction_Contract_TriggerSmartContract,
-						Parameter: &anypb.Any{Value: []byte("test")},
-					},
-				},
-			},
-		},
-		Txid:   []byte("dummytxid"),
-		Result: &api.Return{Result: true},
-	}
-}
-
 func TestSend(t *testing.T) {
 	broadcastCalled := false
 	mc := &mockClient{
@@ -536,7 +517,7 @@ func TestSendAndConfirm_ContextCancelled(t *testing.T) {
 func TestFluentWithPermissionID(t *testing.T) {
 	mc := &mockClient{
 		triggerContractCtxFunc: func(_ context.Context, _, _, _, _ string, _, _ int64, _ string, _ int64) (*api.TransactionExtention, error) {
-			return newDummyTxExt(), nil
+			return newTestTxExt(), nil
 		},
 	}
 
@@ -555,7 +536,7 @@ func TestFluentWithFeeLimit(t *testing.T) {
 	mc := &mockClient{
 		triggerContractCtxFunc: func(_ context.Context, _, _, _, _ string, feeLimit, _ int64, _ string, _ int64) (*api.TransactionExtention, error) {
 			assert.Equal(t, int64(100_000_000), feeLimit)
-			return newDummyTxExt(), nil
+			return newTestTxExt(), nil
 		},
 	}
 
@@ -572,7 +553,7 @@ func TestFluentWithCallValue(t *testing.T) {
 	mc := &mockClient{
 		triggerContractCtxFunc: func(_ context.Context, _, _, _, _ string, _, callValue int64, _ string, _ int64) (*api.TransactionExtention, error) {
 			assert.Equal(t, int64(1_000_000), callValue)
-			return newDummyTxExt(), nil
+			return newTestTxExt(), nil
 		},
 	}
 
@@ -590,7 +571,7 @@ func TestFluentWithTokenValue(t *testing.T) {
 		triggerContractCtxFunc: func(_ context.Context, _, _, _, _ string, _, _ int64, tokenID string, tokenAmount int64) (*api.TransactionExtention, error) {
 			assert.Equal(t, "1000001", tokenID)
 			assert.Equal(t, int64(500), tokenAmount)
-			return newDummyTxExt(), nil
+			return newTestTxExt(), nil
 		},
 	}
 
@@ -610,7 +591,7 @@ func TestFluentChainAll(t *testing.T) {
 			assert.Equal(t, int64(1_000_000), callValue)
 			assert.Equal(t, "1000001", tokenID)
 			assert.Equal(t, int64(100), tokenAmount)
-			return newDummyTxExt(), nil
+			return newTestTxExt(), nil
 		},
 	}
 
@@ -631,7 +612,7 @@ func TestFluentChainAll(t *testing.T) {
 func TestFluentEqualsOption(t *testing.T) {
 	mc := &mockClient{
 		triggerContractCtxFunc: func(_ context.Context, _, _, _, _ string, _, _ int64, _ string, _ int64) (*api.TransactionExtention, error) {
-			return newDummyTxExt(), nil
+			return newTestTxExt(), nil
 		},
 	}
 
@@ -666,7 +647,7 @@ func TestFluentWithData_PermissionAndFeeLimit(t *testing.T) {
 		triggerContractWithDataCtxFunc: func(_ context.Context, _, _ string, data []byte, feeLimit, _ int64, _ string, _ int64) (*api.TransactionExtention, error) {
 			assert.Equal(t, []byte{0xa9, 0x05, 0x9c, 0xbb}, data[:4]) // transfer selector
 			assert.Equal(t, int64(100_000_000), feeLimit)
-			return newDummyTxExt(), nil
+			return newTestTxExt(), nil
 		},
 	}
 


### PR DESCRIPTION
## Summary

Add fluent methods to `ContractCall` for all cross-cutting configuration options, matching the pattern established in txbuilder (#279).

## API

All contract call configuration now supports both functional options and fluent chaining:

```go
// Functional options (existing)
contract.New(c, addr).From(from).Method(sig).
    Apply(contract.WithFeeLimit(100_000_000), contract.WithPermissionID(2)).
    Send(ctx, signer)

// Fluent methods (new)
contract.New(c, addr).From(from).Method(sig).
    WithFeeLimit(100_000_000).
    WithPermissionID(2).
    Send(ctx, signer)

// TRC20 — works with both styles
token.Transfer(from, to, amount).
    WithFeeLimit(100_000_000).
    WithPermissionID(2).
    Send(ctx, signer)
```

## Methods added

| Method | Purpose |
|--------|---------|
| `WithPermissionID(int32)` | Multi-sig permission ID |
| `WithFeeLimit(int64)` | Max energy fee (SUN) |
| `WithCallValue(int64)` | TRX sent with call (SUN) |
| `WithTokenValue(string, int64)` | TRC10 token ID + amount |

No `WithMemo` — smart contract transactions use the Data field for ABI-encoded call data, so memo would corrupt the payload.

## Test plan

- [x] Each fluent method verified independently
- [x] All four chained together in single call
- [x] Equivalence test: fluent vs option APIs produce byte-identical serialized transactions
- [x] WithData path with permission + fee limit
- [x] `make test` — all pass with race detector
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fluent builder support to configure permission IDs, fee limits, call values, and token token amounts, with method chaining for intuitive transaction setup
* **Tests**
  * Added comprehensive tests validating each builder option, method-chaining behavior, combined scenarios, and parity between fluent and functional configuration approaches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->