### PR TITLE
feat(trc20): add LRU metadata cache for name, symbol, and decimals

### DIFF
--- a/pkg/standards/trc20/cache.go
+++ b/pkg/standards/trc20/cache.go
@@ -1,0 +1,185 @@
+package trc20
+
+import (
+	"container/list"
+	"sync"
+)
+
+// Bitmask flags tracking which metadata fields have been populated.
+const (
+	metaName     uint8 = 1 << iota // 1
+	metaSymbol                     // 2
+	metaDecimals                   // 4
+)
+
+// tokenMeta holds the immutable metadata for a single TRC20 contract.
+type tokenMeta struct {
+	name      string
+	symbol    string
+	decimals  uint8
+	populated uint8 // bitmask of metaName | metaSymbol | metaDecimals
+}
+
+// cacheEntry is stored in the LRU list elements.
+type cacheEntry struct {
+	addr string // contract address (map key)
+	meta tokenMeta
+}
+
+// MetadataCache is a thread-safe LRU cache for immutable TRC20 token metadata
+// (name, symbol, decimals). It is safe for concurrent use by multiple
+// goroutines and multiple Token instances.
+//
+// Create with NewMetadataCache and pass to Token via WithCache.
+type MetadataCache struct {
+	mu       sync.Mutex
+	maxSize  int
+	items    map[string]*list.Element
+	eviction *list.List // front = most recently used
+}
+
+// NewMetadataCache creates a cache that holds metadata for up to maxSize
+// contract addresses. When full, the least recently used entry is evicted.
+func NewMetadataCache(maxSize int) *MetadataCache {
+	if maxSize < 1 {
+		maxSize = 1
+	}
+	return &MetadataCache{
+		maxSize:  maxSize,
+		items:    make(map[string]*list.Element, maxSize),
+		eviction: list.New(),
+	}
+}
+
+// Len returns the number of entries currently in the cache.
+func (c *MetadataCache) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.items)
+}
+
+// Evict removes the entry for the given contract address.
+// Returns true if an entry was removed.
+func (c *MetadataCache) Evict(contractAddress string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[contractAddress]; ok {
+		c.removeElement(el)
+		return true
+	}
+	return false
+}
+
+// Clear removes all entries from the cache.
+func (c *MetadataCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[string]*list.Element, c.maxSize)
+	c.eviction.Init()
+}
+
+// getOrCreate returns the entry for addr, creating it if needed.
+// Moves the entry to the front of the LRU list.
+// Caller must hold c.mu.
+func (c *MetadataCache) getOrCreate(addr string) *cacheEntry {
+	if el, ok := c.items[addr]; ok {
+		c.eviction.MoveToFront(el)
+		return el.Value.(*cacheEntry)
+	}
+	// Create new entry, evict if at capacity.
+	entry := &cacheEntry{addr: addr}
+	el := c.eviction.PushFront(entry)
+	c.items[addr] = el
+	if c.eviction.Len() > c.maxSize {
+		c.removeOldest()
+	}
+	return entry
+}
+
+// removeOldest evicts the least recently used entry.
+// Caller must hold c.mu.
+func (c *MetadataCache) removeOldest() {
+	el := c.eviction.Back()
+	if el != nil {
+		c.removeElement(el)
+	}
+}
+
+// removeElement removes an element from both the list and map.
+// Caller must hold c.mu.
+func (c *MetadataCache) removeElement(el *list.Element) {
+	c.eviction.Remove(el)
+	entry := el.Value.(*cacheEntry)
+	delete(c.items, entry.addr)
+}
+
+// --- Package-private get/put methods called by Token ---
+
+func (c *MetadataCache) getName(addr string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[addr]
+	if !ok {
+		return "", false
+	}
+	c.eviction.MoveToFront(el)
+	entry := el.Value.(*cacheEntry)
+	if entry.meta.populated&metaName == 0 {
+		return "", false
+	}
+	return entry.meta.name, true
+}
+
+func (c *MetadataCache) getSymbol(addr string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[addr]
+	if !ok {
+		return "", false
+	}
+	c.eviction.MoveToFront(el)
+	entry := el.Value.(*cacheEntry)
+	if entry.meta.populated&metaSymbol == 0 {
+		return "", false
+	}
+	return entry.meta.symbol, true
+}
+
+func (c *MetadataCache) getDecimals(addr string) (uint8, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	el, ok := c.items[addr]
+	if !ok {
+		return 0, false
+	}
+	c.eviction.MoveToFront(el)
+	entry := el.Value.(*cacheEntry)
+	if entry.meta.populated&metaDecimals == 0 {
+		return 0, false
+	}
+	return entry.meta.decimals, true
+}
+
+func (c *MetadataCache) putName(addr, name string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.getOrCreate(addr)
+	entry.meta.name = name
+	entry.meta.populated |= metaName
+}
+
+func (c *MetadataCache) putSymbol(addr, symbol string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.getOrCreate(addr)
+	entry.meta.symbol = symbol
+	entry.meta.populated |= metaSymbol
+}
+
+func (c *MetadataCache) putDecimals(addr string, decimals uint8) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry := c.getOrCreate(addr)
+	entry.meta.decimals = decimals
+	entry.meta.populated |= metaDecimals
+}

--- a/pkg/standards/trc20/cache_test.go
+++ b/pkg/standards/trc20/cache_test.go
@@ -1,0 +1,310 @@
+package trc20
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- MetadataCache unit tests ---
+
+func TestNewMetadataCache(t *testing.T) {
+	c := NewMetadataCache(100)
+	assert.Equal(t, 0, c.Len())
+}
+
+func TestNewMetadataCache_MinSize(t *testing.T) {
+	c := NewMetadataCache(0)
+	assert.NotNil(t, c)
+	// Should clamp to 1
+	c.putName("A", "TokenA")
+	c.putName("B", "TokenB")
+	assert.Equal(t, 1, c.Len()) // A evicted
+}
+
+func TestCache_PutAndGet(t *testing.T) {
+	c := NewMetadataCache(10)
+
+	c.putName("TUSDT", "Tether USD")
+	c.putSymbol("TUSDT", "USDT")
+	c.putDecimals("TUSDT", 6)
+
+	name, ok := c.getName("TUSDT")
+	assert.True(t, ok)
+	assert.Equal(t, "Tether USD", name)
+
+	symbol, ok := c.getSymbol("TUSDT")
+	assert.True(t, ok)
+	assert.Equal(t, "USDT", symbol)
+
+	decimals, ok := c.getDecimals("TUSDT")
+	assert.True(t, ok)
+	assert.Equal(t, uint8(6), decimals)
+}
+
+func TestCache_MissReturnsNotOk(t *testing.T) {
+	c := NewMetadataCache(10)
+
+	_, ok := c.getName("TUSDT")
+	assert.False(t, ok)
+
+	_, ok = c.getSymbol("TUSDT")
+	assert.False(t, ok)
+
+	_, ok = c.getDecimals("TUSDT")
+	assert.False(t, ok)
+}
+
+func TestCache_PartialPopulation(t *testing.T) {
+	c := NewMetadataCache(10)
+
+	// Only populate decimals
+	c.putDecimals("TUSDT", 6)
+
+	// Decimals should hit
+	d, ok := c.getDecimals("TUSDT")
+	assert.True(t, ok)
+	assert.Equal(t, uint8(6), d)
+
+	// Name and symbol should miss (not populated)
+	_, ok = c.getName("TUSDT")
+	assert.False(t, ok)
+	_, ok = c.getSymbol("TUSDT")
+	assert.False(t, ok)
+
+	// Now populate symbol
+	c.putSymbol("TUSDT", "USDT")
+	symbol, ok := c.getSymbol("TUSDT")
+	assert.True(t, ok)
+	assert.Equal(t, "USDT", symbol)
+
+	// Name still missing
+	_, ok = c.getName("TUSDT")
+	assert.False(t, ok)
+}
+
+func TestCache_LRUEviction(t *testing.T) {
+	c := NewMetadataCache(3)
+
+	c.putName("A", "TokenA")
+	c.putName("B", "TokenB")
+	c.putName("C", "TokenC")
+	assert.Equal(t, 3, c.Len())
+
+	// Adding D should evict A (least recently used)
+	c.putName("D", "TokenD")
+	assert.Equal(t, 3, c.Len())
+
+	_, ok := c.getName("A")
+	assert.False(t, ok, "A should have been evicted")
+
+	_, ok = c.getName("B")
+	assert.True(t, ok)
+	_, ok = c.getName("D")
+	assert.True(t, ok)
+}
+
+func TestCache_LRUAccessUpdatesRecency(t *testing.T) {
+	c := NewMetadataCache(3)
+
+	c.putName("A", "TokenA")
+	c.putName("B", "TokenB")
+	c.putName("C", "TokenC")
+
+	// Access A to move it to front
+	c.getName("A")
+
+	// Adding D should evict B (now least recently used), not A
+	c.putName("D", "TokenD")
+
+	_, ok := c.getName("A")
+	assert.True(t, ok, "A should still be cached after access")
+
+	_, ok = c.getName("B")
+	assert.False(t, ok, "B should have been evicted")
+}
+
+func TestCache_Evict(t *testing.T) {
+	c := NewMetadataCache(10)
+
+	c.putName("TUSDT", "Tether USD")
+	c.putDecimals("TUSDT", 6)
+
+	removed := c.Evict("TUSDT")
+	assert.True(t, removed)
+	assert.Equal(t, 0, c.Len())
+
+	_, ok := c.getName("TUSDT")
+	assert.False(t, ok)
+
+	// Evicting non-existent returns false
+	removed = c.Evict("nonexistent")
+	assert.False(t, removed)
+}
+
+func TestCache_Clear(t *testing.T) {
+	c := NewMetadataCache(10)
+
+	c.putName("A", "TokenA")
+	c.putName("B", "TokenB")
+	c.putName("C", "TokenC")
+	assert.Equal(t, 3, c.Len())
+
+	c.Clear()
+	assert.Equal(t, 0, c.Len())
+
+	_, ok := c.getName("A")
+	assert.False(t, ok)
+}
+
+func TestCache_ConcurrentAccess(t *testing.T) {
+	c := NewMetadataCache(100)
+	var wg sync.WaitGroup
+
+	// 10 goroutines writing different keys
+	for i := range 10 {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			addr := string(rune('A' + id))
+			for range 100 {
+				c.putName(addr, "Token"+addr)
+				c.putSymbol(addr, addr)
+				c.putDecimals(addr, uint8(id))
+				c.getName(addr)
+				c.getSymbol(addr)
+				c.getDecimals(addr)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Should not panic or corrupt state
+	assert.LessOrEqual(t, c.Len(), 100)
+}
+
+// --- Token integration tests with cache ---
+
+func TestToken_CacheReducesRPCCalls(t *testing.T) {
+	// Only one result in the queue — if second Decimals() call hits RPC,
+	// it will get nil results and fail. Cache makes it succeed.
+	mc := &mockClient{
+		results: [][][]byte{
+			{abiEncodeUint256(big.NewInt(6))},
+			// No more results — second RPC call would fail
+		},
+	}
+
+	cache := NewMetadataCache(10)
+	token := New(mc, "TContract", WithCache(cache))
+
+	// First call — hits RPC, populates cache
+	d1, err := token.Decimals(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(6), d1)
+
+	// Second call — must use cache (no RPC results left)
+	d2, err := token.Decimals(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, uint8(6), d2)
+
+	// Verify cache has the entry
+	cached, ok := cache.getDecimals("TContract")
+	assert.True(t, ok)
+	assert.Equal(t, uint8(6), cached)
+}
+
+func TestToken_NoCacheBackwardCompatible(t *testing.T) {
+	mc := &mockClient{
+		constantResult: [][]byte{abiEncodeString("Tether USD")},
+	}
+
+	// No WithCache — existing behavior
+	token := New(mc, "TContract")
+
+	name, err := token.Name(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "Tether USD", name)
+}
+
+func TestToken_CacheSharedAcrossInstances(t *testing.T) {
+	mc := &mockClient{
+		constantResult: [][]byte{abiEncodeString("USDT")},
+	}
+
+	cache := NewMetadataCache(10)
+
+	// Two Token instances for the same contract, sharing a cache
+	t1 := New(mc, "TContract", WithCache(cache))
+	t2 := New(mc, "TContract", WithCache(cache))
+
+	// First instance populates cache
+	sym1, err := t1.Symbol(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "USDT", sym1)
+
+	// Second instance should get cache hit
+	sym2, err := t2.Symbol(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "USDT", sym2)
+}
+
+func TestToken_EvictForcesRefetch(t *testing.T) {
+	mc := &mockClient{
+		results: [][][]byte{
+			{abiEncodeString("OldName")},
+			{abiEncodeString("NewName")}, // returned after eviction
+		},
+	}
+
+	cache := NewMetadataCache(10)
+	token := New(mc, "TContract", WithCache(cache))
+
+	// First call populates cache
+	name, err := token.Name(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "OldName", name)
+
+	// Evict forces next call to hit RPC
+	cache.Evict("TContract")
+
+	// Second call hits RPC again (cache evicted), gets "NewName"
+	name, err = token.Name(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "NewName", name)
+}
+
+func TestToken_BalanceOfUsesCachedDecimals(t *testing.T) {
+	mc := &mockClient{
+		results: [][][]byte{
+			// First call: balanceOf
+			{abiEncodeUint256(big.NewInt(1_500_000))},
+			// Second call: decimals
+			{abiEncodeUint256(big.NewInt(6))},
+			// Third call: symbol
+			{abiEncodeString("USDT")},
+			// Fourth call: balanceOf again
+			{abiEncodeUint256(big.NewInt(2_000_000))},
+			// decimals and symbol should come from cache — no more RPC results needed
+		},
+	}
+
+	cache := NewMetadataCache(10)
+	token := New(mc, "TSvT6Bg3siokv3dbdtt9o4oM1CTXmymGn1", WithCache(cache))
+
+	// First BalanceOf — fetches balance, decimals, symbol from RPC
+	bal1, err := token.BalanceOf(context.Background(), "TSvT6Bg3siokv3dbdtt9o4oM1CTXmymGn1")
+	require.NoError(t, err)
+	assert.Equal(t, "1.5", bal1.Display)
+	assert.Equal(t, "USDT", bal1.Symbol)
+
+	// Second BalanceOf — fetches balance from RPC, decimals and symbol from cache
+	bal2, err := token.BalanceOf(context.Background(), "TSvT6Bg3siokv3dbdtt9o4oM1CTXmymGn1")
+	require.NoError(t, err)
+	assert.Equal(t, "2", bal2.Display)
+	assert.Equal(t, "USDT", bal2.Symbol)
+}

--- a/pkg/standards/trc20/token.go
+++ b/pkg/standards/trc20/token.go
@@ -46,14 +46,32 @@ type Balance struct {
 type Token struct {
 	client          contract.Client
 	contractAddress string
+	cache           *MetadataCache // nil means no caching (opt-in)
+}
+
+// TokenOption configures optional Token behavior.
+type TokenOption func(*Token)
+
+// WithCache enables metadata caching for this Token instance. Cached fields
+// (name, symbol, decimals) are fetched from the network once and served from
+// memory on subsequent calls. The same MetadataCache should be shared across
+// Token instances to benefit from cross-instance cache hits.
+func WithCache(c *MetadataCache) TokenOption {
+	return func(t *Token) {
+		t.cache = c
+	}
 }
 
 // New creates a Token instance for the given TRC20 contract.
-func New(client contract.Client, contractAddress string) *Token {
-	return &Token{
+func New(client contract.Client, contractAddress string, opts ...TokenOption) *Token {
+	t := &Token{
 		client:          client,
 		contractAddress: contractAddress,
 	}
+	for _, opt := range opts {
+		opt(t)
+	}
+	return t
 }
 
 // Info retrieves the token name, symbol, decimals, and total supply.
@@ -82,8 +100,15 @@ func (t *Token) Info(ctx context.Context) (*TokenInfo, error) {
 	}, nil
 }
 
-// Name returns the token name.
+// Name returns the token name. If a MetadataCache is configured, the result
+// is cached after the first successful fetch.
 func (t *Token) Name(ctx context.Context) (string, error) {
+	if t.cache != nil {
+		if name, ok := t.cache.getName(t.contractAddress); ok {
+			return name, nil
+		}
+	}
+
 	data, err := hex.DecodeString(selectorName)
 	if err != nil {
 		return "", err
@@ -94,11 +119,26 @@ func (t *Token) Name(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return decodeString(result.RawResults)
+	name, err := decodeString(result.RawResults)
+	if err != nil {
+		return "", err
+	}
+
+	if t.cache != nil {
+		t.cache.putName(t.contractAddress, name)
+	}
+	return name, nil
 }
 
-// Symbol returns the token symbol.
+// Symbol returns the token symbol. If a MetadataCache is configured, the
+// result is cached after the first successful fetch.
 func (t *Token) Symbol(ctx context.Context) (string, error) {
+	if t.cache != nil {
+		if symbol, ok := t.cache.getSymbol(t.contractAddress); ok {
+			return symbol, nil
+		}
+	}
+
 	data, err := hex.DecodeString(selectorSymbol)
 	if err != nil {
 		return "", err
@@ -109,11 +149,26 @@ func (t *Token) Symbol(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return decodeString(result.RawResults)
+	symbol, err := decodeString(result.RawResults)
+	if err != nil {
+		return "", err
+	}
+
+	if t.cache != nil {
+		t.cache.putSymbol(t.contractAddress, symbol)
+	}
+	return symbol, nil
 }
 
-// Decimals returns the token decimals.
+// Decimals returns the token decimals. If a MetadataCache is configured, the
+// result is cached after the first successful fetch.
 func (t *Token) Decimals(ctx context.Context) (uint8, error) {
+	if t.cache != nil {
+		if d, ok := t.cache.getDecimals(t.contractAddress); ok {
+			return d, nil
+		}
+	}
+
 	data, err := hex.DecodeString(selectorDecimals)
 	if err != nil {
 		return 0, err
@@ -131,7 +186,12 @@ func (t *Token) Decimals(ctx context.Context) (uint8, error) {
 	if !n.IsUint64() || n.Uint64() > 255 {
 		return 0, fmt.Errorf("decimals value %s out of uint8 range", n.String())
 	}
-	return uint8(n.Uint64()), nil
+	d := uint8(n.Uint64())
+
+	if t.cache != nil {
+		t.cache.putDecimals(t.contractAddress, d)
+	}
+	return d, nil
 }
 
 // TotalSupply returns the total token supply.


### PR DESCRIPTION
## Summary

Add an opt-in LRU cache for immutable TRC20 token metadata, eliminating redundant RPC calls for `Name()`, `Symbol()`, and `Decimals()`.

## Problem

Every call to `BalanceOf()` makes 3 RPC round-trips (balance + decimals + symbol). For services querying the same tokens repeatedly (exchanges, wallets, bots), this is wasteful — name, symbol, and decimals never change after deployment.

## Solution

```go
// Create a shared cache at startup
cache := trc20.NewMetadataCache(500)

// Pass to token instances
usdt := trc20.New(client, usdtAddr, trc20.WithCache(cache))

usdt.Decimals(ctx)  // RPC call, result cached
usdt.Decimals(ctx)  // cache hit, no RPC

// BalanceOf automatically uses cached decimals/symbol
usdt.BalanceOf(ctx, addr) // 3 RPCs first time, 1 RPC after

// Cache management
cache.Evict(addr)  // invalidate single token (e.g. proxy upgrade)
cache.Clear()      // invalidate all
cache.Len()        // monitoring
```

## Design

- **LRU eviction** with configurable max size (`container/list` + `sync.Mutex`)
- **Per-field bitmask** — fields are cached independently as they're fetched (decimals cached before name is ever called)
- **Thread-safe** — `sync.Mutex` (not RWMutex, since LRU Get mutates the list)
- **Shared across instances** — same `MetadataCache` serves multiple `Token` instances for the same contract
- **Opt-in** — `New(client, addr)` without `WithCache` works exactly as before
- **Zero dependencies** — stdlib only (`container/list`, `sync`)

## What is cached vs not cached

| Field | Cached | Reason |
|-------|--------|--------|
| Name | Yes | Immutable after deployment |
| Symbol | Yes | Immutable after deployment |
| Decimals | Yes | Immutable after deployment |
| TotalSupply | No | Changes with mints/burns |
| BalanceOf | No | Changes every transfer |
| Allowance | No | Changes with approve/transferFrom |

## Test plan

- [x] LRU eviction (oldest entry removed when full)
- [x] Access updates recency (prevents wrong eviction)
- [x] Partial population (cache decimals without name)
- [x] Cache miss returns false
- [x] Evict single entry / Clear all
- [x] Concurrent goroutine safety (10 goroutines × 100 ops)
- [x] Cache reduces RPC calls (second call succeeds with no mock results left)
- [x] Shared across Token instances
- [x] Evict forces re-fetch from network
- [x] BalanceOf uses cached decimals/symbol (5 sequential mock results prove it)
- [x] Backward compatible (no WithCache = no caching)
- [x] `make test` — 76 tests pass with race detector
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional metadata caching for TRC20 tokens, reducing redundant network requests for token name, symbol, and decimal information
  * Cache is configurable and fully backward compatible—existing code operates unchanged without explicit opt-in

* **Tests**
  * Comprehensive test suite for cache functionality, including LRU eviction, concurrent access, and integration with token operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->