### PR TITLE
feat: add .Sign() terminal and WithdrawExpireUnfreeze decode support

### DIFF
--- a/pkg/client/transaction/decode.go
+++ b/pkg/client/transaction/decode.go
@@ -63,6 +63,8 @@ func DecodeContractData(tx *core.Transaction) (*ContractData, error) {
 		return decodeDelegateResourceContract(paramValue)
 	case core.Transaction_Contract_UnDelegateResourceContract:
 		return decodeUnDelegateResourceContract(paramValue)
+	case core.Transaction_Contract_WithdrawExpireUnfreezeContract:
+		return decodeWithdrawExpireUnfreezeContract(paramValue)
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedContract, contractType.String())
 	}
@@ -198,6 +200,19 @@ func decodeUnDelegateResourceContract(data []byte) (*ContractData, error) {
 			"receiver_address": address.Address(c.GetReceiverAddress()).String(),
 			"balance":          sunToTRX(c.GetBalance()),
 			"resource":         c.GetResource().String(),
+		},
+	}, nil
+}
+
+func decodeWithdrawExpireUnfreezeContract(data []byte) (*ContractData, error) {
+	var c core.WithdrawExpireUnfreezeContract
+	if err := proto.Unmarshal(data, &c); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUnmarshalContract, err)
+	}
+	return &ContractData{
+		Type: "WithdrawExpireUnfreezeContract",
+		Fields: map[string]any{
+			"owner_address": address.Address(c.GetOwnerAddress()).String(),
 		},
 	}, nil
 }

--- a/pkg/client/transaction/decode_test.go
+++ b/pkg/client/transaction/decode_test.go
@@ -329,3 +329,16 @@ func TestSunToTRX(t *testing.T) {
 		})
 	}
 }
+
+func TestDecodeContractData_WithdrawExpireUnfreezeContract(t *testing.T) {
+	owner := testAddr(0x10)
+	tx := buildTx(core.Transaction_Contract_WithdrawExpireUnfreezeContract, &core.WithdrawExpireUnfreezeContract{
+		OwnerAddress: owner,
+	})
+
+	result, err := DecodeContractData(tx)
+	require.NoError(t, err)
+
+	assert.Equal(t, "WithdrawExpireUnfreezeContract", result.Type)
+	assert.Equal(t, address.Address(owner).String(), result.Fields["owner_address"])
+}

--- a/pkg/contract/builder.go
+++ b/pkg/contract/builder.go
@@ -283,6 +283,16 @@ func (c *ContractCall) Build(ctx context.Context) (*api.TransactionExtention, er
 	return tx, nil
 }
 
+// Sign builds and signs the transaction without broadcasting. Returns the
+// signed transaction ready for deferred broadcast or inspection.
+func (c *ContractCall) Sign(ctx context.Context, s signer.Signer) (*core.Transaction, error) {
+	tx, err := c.Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.Sign(tx.GetTransaction())
+}
+
 // Send builds, signs, and broadcasts a state-changing transaction.
 func (c *ContractCall) Send(ctx context.Context, s signer.Signer) (*Receipt, error) {
 	tx, err := c.Build(ctx)

--- a/pkg/contract/builder_test.go
+++ b/pkg/contract/builder_test.go
@@ -453,6 +453,50 @@ func (s *mockSigner) Sign(tx *core.Transaction) (*core.Transaction, error) {
 
 func (s *mockSigner) Address() address.Address { return nil }
 
+func TestSign(t *testing.T) {
+	mc := &mockClient{
+		triggerContractCtxFunc: func(_ context.Context, _, _, _, _ string, _, _ int64, _ string, _ int64) (*api.TransactionExtention, error) {
+			return newTestTxExt(), nil
+		},
+	}
+
+	signed, err := New(mc, "TContract").
+		Method("transfer(address,uint256)").
+		From("TFrom").
+		Sign(context.Background(), &mockSigner{})
+	require.NoError(t, err)
+	require.NotNil(t, signed)
+	assert.NotEmpty(t, signed.Signature, "transaction should be signed")
+}
+
+func TestSign_WithPermissionID(t *testing.T) {
+	mc := &mockClient{
+		triggerContractCtxFunc: func(_ context.Context, _, _, _, _ string, _, _ int64, _ string, _ int64) (*api.TransactionExtention, error) {
+			return newTestTxExt(), nil
+		},
+	}
+
+	signed, err := New(mc, "TContract").
+		Method("transfer(address,uint256)").
+		From("TFrom").
+		WithPermissionID(2).
+		Sign(context.Background(), &mockSigner{})
+	require.NoError(t, err)
+	for _, c := range signed.RawData.Contract {
+		assert.Equal(t, int32(2), c.PermissionId)
+	}
+}
+
+func TestSign_NoFrom(t *testing.T) {
+	mc := &mockClient{}
+
+	_, err := New(mc, "TContract").
+		Method("test()").
+		Sign(context.Background(), &mockSigner{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "From address is required")
+}
+
 func TestSend(t *testing.T) {
 	broadcastCalled := false
 	mc := &mockClient{

--- a/pkg/txbuilder/builder.go
+++ b/pkg/txbuilder/builder.go
@@ -105,6 +105,16 @@ func (t *Tx) Build(ctx context.Context) (*api.TransactionExtention, error) {
 	return tx, nil
 }
 
+// Sign builds and signs the transaction without broadcasting. Returns the
+// signed transaction ready for deferred broadcast or inspection.
+func (t *Tx) Sign(ctx context.Context, s signer.Signer) (*core.Transaction, error) {
+	ext, err := t.Build(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return s.Sign(ext.Transaction)
+}
+
 // Decode builds the transaction and decodes the first contract parameter into
 // human-readable fields (base58 addresses, TRX-formatted amounts). Useful for
 // inspecting or displaying what a transaction does before signing.

--- a/pkg/txbuilder/builder_test.go
+++ b/pkg/txbuilder/builder_test.go
@@ -124,6 +124,42 @@ func newDummyTxExt() *api.TransactionExtention {
 	}
 }
 
+func TestTransfer_Sign(t *testing.T) {
+	mc := &mockClient{
+		transferFn: func(_ context.Context, _, _ string, _ int64) (*api.TransactionExtention, error) {
+			return newDummyTxExt(), nil
+		},
+	}
+
+	s := &mockSigner{}
+	b := New(mc)
+	signed, err := b.Transfer("TFrom", "TTo", 100).Sign(context.Background(), s)
+	require.NoError(t, err)
+	require.NotNil(t, signed)
+	assert.NotEmpty(t, signed.Signature, "transaction should be signed")
+	// Should NOT have been broadcast (no broadcastFn set, would panic if called)
+}
+
+func TestTransfer_SignWithMemoAndPermission(t *testing.T) {
+	mc := &mockClient{
+		transferFn: func(_ context.Context, _, _ string, _ int64) (*api.TransactionExtention, error) {
+			return newDummyTxExt(), nil
+		},
+	}
+
+	s := &mockSigner{}
+	b := New(mc)
+	signed, err := b.Transfer("TFrom", "TTo", 100).
+		WithMemo("test memo").
+		WithPermissionID(2).
+		Sign(context.Background(), s)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("test memo"), signed.RawData.Data)
+	for _, c := range signed.RawData.Contract {
+		assert.Equal(t, int32(2), c.PermissionId)
+	}
+}
+
 func TestTransfer_Build(t *testing.T) {
 	mc := &mockClient{
 		transferFn: func(_ context.Context, from, to string, amount int64) (*api.TransactionExtention, error) {


### PR DESCRIPTION
## Summary

- Add `.Sign()` terminal to `txbuilder.Tx` and `contract.ContractCall`
- Add `WithdrawExpireUnfreezeContract` decode support to `DecodeContractData`

Closes #283

## .Sign() terminal

Builds and signs the transaction without broadcasting — useful for deferred broadcast or transaction inspection.

```go
// txbuilder
signed, err := b.Transfer(from, to, amount).WithMemo("payment").Sign(ctx, signer)

// contract
signed, err := contract.New(c, addr).From(from).Method(sig).WithPermissionID(2).Sign(ctx, signer)
```

Available on all transaction types via embedding (`DelegateTx`, `VoteTx` inherit from `Tx`).

## Complete fluent terminal set

| Terminal | What it does |
|----------|-------------|
| `.Build(ctx)` | Unsigned transaction |
| `.Sign(ctx, signer)` | Signed transaction, no broadcast **(new)** |
| `.Send(ctx, signer)` | Sign + broadcast |
| `.SendAndConfirm(ctx, signer)` | Sign + broadcast + wait for confirmation |
| `.Decode(ctx)` | Human-readable contract fields |

## DecodeContractData coverage

All native contract types now supported:

| Contract | Status |
|----------|--------|
| TransferContract | existing |
| TransferAssetContract | existing |
| TriggerSmartContract | existing |
| FreezeBalanceV2Contract | existing |
| UnfreezeBalanceV2Contract | existing |
| VoteWitnessContract | existing |
| DelegateResourceContract | existing |
| UnDelegateResourceContract | existing |
| WithdrawExpireUnfreezeContract | **new** |

## Test plan

- [x] `TestTransfer_Sign` — signs without broadcast
- [x] `TestTransfer_SignWithMemoAndPermission` — memo and permissionID applied before signing
- [x] `TestSign` (contract) — signs without broadcast
- [x] `TestSign_WithPermissionID` — permissionID applied before signing
- [x] `TestSign_NoFrom` — error when From not set
- [x] `TestDecodeContractData_WithdrawExpireUnfreezeContract` — decodes owner_address
- [x] `make test` — all pass with race detector
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for decoding and processing WithdrawExpireUnfreezeContract transaction type.
  * Introduced Sign methods for contract calls and transactions, allowing users to sign without broadcasting. Support for permission IDs and memos is included.

* **Tests**
  * Added comprehensive test coverage for new signing functionality and contract decoding features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->