### PR TITLE
fix(cli): stop --estimate broadcasting and correct out-of-range arg indexing

### DIFF
--- a/cmd/subcommands/contract.go
+++ b/cmd/subcommands/contract.go
@@ -299,7 +299,7 @@ func contractTriggerCmd() *cobra.Command {
 				if err != nil {
 					return err
 				}
-				tokenInt = int64(tAmount * math.Pow10(int(info.Precision)))
+				tokenInt = int64(tTokenAmount * math.Pow10(int(info.Precision)))
 			}
 
 			param := ""
@@ -335,8 +335,14 @@ func contractTriggerCmd() *cobra.Command {
 					"result":  estimate.Result.Result,
 				}
 
-				asJSON, _ := json.Marshal(result)
+				asJSON, err := json.Marshal(result)
+				if err != nil {
+					return err
+				}
 				fmt.Println(common.JSONPrettyFormat(string(asJSON)))
+				// --estimate is a dry run: never fall through to TriggerContract,
+				// which would sign and broadcast a real state-changing call.
+				return nil
 			}
 
 			tx, err := conn.TriggerContract(
@@ -402,7 +408,8 @@ func contractTriggerCmd() *cobra.Command {
 	cmd.Flags().Float64Var(&tAmount, "value", 0, "trx amount")
 	cmd.Flags().StringVar(&tTokenID, "token", "", "token id")
 	cmd.Flags().Float64Var(&tTokenAmount, "tokenValue", 0, "token amount")
-	cmd.Flags().BoolVar(&estimate, "estimate", false, "estimate energy required")
+	cmd.Flags().BoolVar(&estimate, "estimate", false,
+		"only estimate the energy required; do not sign or broadcast the call")
 	return cmd
 }
 

--- a/cmd/subcommands/trc10.go
+++ b/cmd/subcommands/trc10.go
@@ -189,7 +189,7 @@ func trc10SendCmd() *cobra.Command {
 						tokenDecimals = asset.Precision
 					}
 				} else {
-					return fmt.Errorf("TRC10 not found: %s", args[3])
+					return fmt.Errorf("TRC10 not found: %s", args[2])
 				}
 			}
 			if len(tokenID) == 0 {
@@ -199,10 +199,10 @@ func trc10SendCmd() *cobra.Command {
 						tokenID = asset.Id
 						tokenDecimals = asset.Precision
 					} else {
-						return fmt.Errorf("TRC10 not found: %s", args[3])
+						return fmt.Errorf("TRC10 not found: %s", args[2])
 					}
 				} else {
-					return fmt.Errorf("TRC10 not found: %s", args[3])
+					return fmt.Errorf("TRC10 not found: %s", args[2])
 				}
 			}
 


### PR DESCRIPTION
## Summary

Three critical CLI defects, all one-token corrections. Wave 0 of the repository review — the hotfix
tier.

### `contract trigger --estimate` broadcast a real transaction

The `--estimate` block printed the energy estimate and then **fell through** to `TriggerContract`,
signing and broadcasting a real state-changing call. Only the `noPrettyOutput` branch returned early,
so the two output modes of the same flag disagreed:

```go
if noPrettyOutput {
    fmt.Println(estimate)
    return nil          // <-- returned
}
...
fmt.Println(common.JSONPrettyFormat(string(asJSON)))
}                       // <-- no return; fell through to TriggerContract
```

A user running a dry run in default (pretty) output mode spent real TRX and energy. The estimate
printed first, so the output looked like a successful dry run right up until the transaction result
appeared.

The flag exists because of #44 ("Estimate transaction TRC20 fee") and #66, whose reference is TRON's
[how to estimate energy consumption](https://developers.tron.network/docs/set-feelimit#how-to-estimate-energy-consumption)
— a guide for **choosing a `feeLimit`**. The intended workflow is estimate → pick a `feeLimit` →
execute: two commands. Consistent with that, `estimate.EnergyRequired` is read exactly once in the
whole `cmd/` tree, into a print map; it never feeds `feeLimit`, which is an independent flag.

Flag help updated from `"estimate energy required"` to state that it neither signs nor broadcasts.

### TRC10 amount computed from the wrong flag

The guard tested `tTokenAmount` (`--tokenValue`) but the computation read `tAmount` (`--value`):

```go
if tTokenAmount > 0 {
    tokenInt = int64(tAmount * math.Pow10(int(info.Precision)))
    //                ^^^^^^^ should be tTokenAmount
}
```

With `--tokenValue 100` and no `--value`, the TRC10 amount attached to the call was `0`. With both
set, the token amount silently became the TRX amount.

### Out-of-range index panic in `trc10 send`

Three `TRC10 not found` error paths indexed `args[3]` on an `ExactArgs(3)` command (valid indices
0–2), panicking instead of reporting the error. `args[3]` at `trc10.go:107` is **not** affected — that
is `trc10 issue`, which also reads `args[4]` and takes more arguments.

## Also

Checked the `json.Marshal` error in the estimate branch instead of discarding it, per the
project convention against blank `_` on error returns.

## Testing

`make lint` (0 issues) · `make test` (20/20 packages) · `make` · `go vet ./cmd/...` — all clean.
Flag help verified against the built binary.

**No automated regression test for the `--estimate` fix.** There are zero test files under `cmd/`
(the test target excludes it) and `conn` is a package-level `*client.GrpcClient` — a concrete pointer
with no interface seam to mock. Adding one means introducing a `conn` interface across every
subcommand, which does not belong in a hotfix for an active money-loss bug. Tracked for the CLI test
PR.

## Follow-up

A separate PR will add `--autoFeeLimit`, deriving `feeLimit` from the estimate so the two-command
workflow collapses into one — requires a new `GetChainParameters` client wrapper, and must clamp
against a ceiling the node cannot influence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token amount calculations when triggering contracts.
  * Fixed estimate mode to stop after displaying results without signing or broadcasting a transaction.
  * Improved error handling when estimate results cannot be formatted.
  * Updated estimate help text to clarify its behavior.
  * Corrected TRC10 token lookup errors to display the appropriate token identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->