### PR TITLE
fix(cli): version check panics, hangs, and misreports release builds

### DIFF
--- a/cmd/subcommands/root.go
+++ b/cmd/subcommands/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -141,6 +141,16 @@ var (
 	versionTagLink  = "https://api.github.com/repos/fbsobreira/gotron-sdk/git/ref/tags/"
 )
 
+const (
+	// versionCheckTimeout bounds the whole version check. getGitVersion runs from
+	// Execute on every command failure, so an unreachable or hung endpoint would
+	// otherwise delay the user's real error indefinitely — offline use included.
+	versionCheckTimeout = 3 * time.Second
+	// shortCommitLen is the abbreviation width used for the local commit, by both
+	// goreleaser's .ShortCommit and the build-info truncation in cmd/tronctl/main.go.
+	shortCommitLen = 7
+)
+
 // GitHubReleaseAssets json struct
 type GitHubReleaseAssets struct {
 	ID   json.Number `json:"id"`
@@ -164,58 +174,97 @@ type GitHubTag struct {
 	NodeID string `json:"node_id"`
 	URL    string `json:"url"`
 	DATA   struct {
-		SHA string `json:"sha"`
+		SHA  string `json:"sha"`
+		Type string `json:"type"`
 	} `json:"object"`
 }
 
-func getGitVersion() (string, error) {
-	resp, err := http.Get(versionLink)
+// fetchJSON performs a bounded GET and decodes a JSON body into out.
+func fetchJSON(ctx context.Context, url string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return "", err
+		return err
 	}
-
-	if resp != nil {
-		defer func() { _ = resp.Body.Close() }()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
 	}
-	// if error, no op
-	if resp != nil && resp.StatusCode == 200 {
-		buf := new(bytes.Buffer)
-		_, err = buf.ReadFrom(resp.Body)
-		if err != nil {
-			return "", err
-		}
-		release := &GitHubRelease{}
-		if err := json.Unmarshal(buf.Bytes(), release); err != nil {
-			return "", err
-		}
+	defer func() { _ = resp.Body.Close() }()
 
-		respTag, err := http.Get(versionTagLink + release.TagName)
-		if err != nil || respTag == nil {
-			return "", fmt.Errorf("failed to fetch tag: %w", err)
-		}
-		defer func() { _ = respTag.Body.Close() }()
-		if respTag.StatusCode == 200 {
-			buf.Reset()
-			_, err := buf.ReadFrom(respTag.Body)
-			if err != nil {
-				return "", err
-			}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: unexpected status %s", url, resp.Status)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
 
-			releaseTag := &GitHubTag{}
-			if err := json.Unmarshal(buf.Bytes(), releaseTag); err != nil {
-				return "", err
-			}
-			commit := strings.Split(VersionWrapDump, "-")
-
-			if releaseTag.DATA.SHA[:8] != commit[1] {
-				warnMsg := fmt.Sprintf("Warning: Using outdated version. Redownload to upgrade to %s\n", release.TagName)
-				fmt.Fprintf(os.Stderr, "%s", color.RedString(warnMsg))
-				return release.TagName, fmt.Errorf("%s", warnMsg)
-			}
-			return release.TagName, nil
+func isHexString(s string) bool {
+	for _, r := range s {
+		if !strings.ContainsRune("0123456789abcdefABCDEF", r) {
+			return false
 		}
 	}
-	return "", fmt.Errorf("could not fetch version")
+	return true
+}
+
+// shortCommit returns the abbreviated commit hash that main appends to
+// VersionWrapDump as "<version>-<commit>", or "" when this build carries no
+// usable commit information.
+//
+// It scans back to front for the last hex field of at least shortCommitLen, so
+// it stays correct for every shape the build actually produces: "v0.26.0-abc1234"
+// from goreleaser, "v366-5484f0cc-dirty" from the Makefile, and prerelease tags
+// like "v0.27.0-rc1-abc1234" where a fixed field index would pick up "rc1".
+//
+// It never indexes blindly: getGitVersion runs while reporting an ordinary error,
+// so a panic here would replace the user's real message with a stack trace.
+func shortCommit(dump string) string {
+	fields := strings.Split(dump, "-")
+	for i := len(fields) - 1; i >= 1; i-- {
+		if len(fields[i]) >= shortCommitLen && isHexString(fields[i]) {
+			return fields[i]
+		}
+	}
+	return ""
+}
+
+func getGitVersion() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), versionCheckTimeout)
+	defer cancel()
+
+	release := &GitHubRelease{}
+	if err := fetchJSON(ctx, versionLink, release); err != nil {
+		return "", fmt.Errorf("could not fetch version: %w", err)
+	}
+
+	releaseTag := &GitHubTag{}
+	if err := fetchJSON(ctx, versionTagLink+release.TagName, releaseTag); err != nil {
+		return "", fmt.Errorf("failed to fetch tag %s: %w", release.TagName, err)
+	}
+
+	// An annotated tag points at a tag object, not at a commit, so its sha is not
+	// comparable with this build's commit. Report the tag rather than claiming the
+	// build is outdated on a value that was never the commit. (Releases are tagged
+	// lightweight today; this guards the day one is annotated.)
+	if releaseTag.DATA.Type != "" && releaseTag.DATA.Type != "commit" {
+		return release.TagName, nil
+	}
+
+	// No commit recorded in this build, or none reported by the API: there is
+	// nothing to compare, so do not claim the build is outdated.
+	localCommit := shortCommit(VersionWrapDump)
+	if localCommit == "" || releaseTag.DATA.SHA == "" {
+		return release.TagName, nil
+	}
+
+	// The local commit is an abbreviation while the API returns the full 40-char
+	// sha, so compare by prefix. The previous sha[:8] != <7-char abbreviation>
+	// could never be equal, which made every release build report itself outdated.
+	if !strings.HasPrefix(releaseTag.DATA.SHA, localCommit) {
+		warnMsg := fmt.Sprintf("Warning: Using outdated version. Redownload to upgrade to %s\n", release.TagName)
+		fmt.Fprintf(os.Stderr, "%s", color.RedString(warnMsg))
+		return release.TagName, fmt.Errorf("%s", warnMsg)
+	}
+	return release.TagName, nil
 }
 
 // Execute kicks off the tronctl CLI

--- a/cmd/subcommands/root_test.go
+++ b/cmd/subcommands/root_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import "testing"
+
+func TestShortCommit(t *testing.T) {
+	tests := []struct {
+		name string
+		dump string
+		want string
+	}{
+		{
+			name: "goreleaser release build",
+			dump: "v0.26.0-abc1234",
+			want: "abc1234",
+		},
+		{
+			name: "makefile local build carries a dirty suffix",
+			dump: "v366-5484f0cc-dirty",
+			want: "5484f0cc",
+		},
+		{
+			name: "prerelease tag must not yield the prerelease identifier",
+			dump: "v0.27.0-rc1-abc1234",
+			want: "abc1234",
+		},
+		{
+			name: "prerelease identifier long enough to look like a hash is still skipped",
+			dump: "v0.27.0-beta123-abc1234",
+			want: "abc1234",
+		},
+		{
+			// main.go sets VersionWrapDump to the bare version when no commit is
+			// recorded. Indexing field 1 here is what panicked in getGitVersion.
+			name: "no commit recorded",
+			dump: "v0.26.0",
+			want: "",
+		},
+		{
+			name: "empty dump",
+			dump: "",
+			want: "",
+		},
+		{
+			name: "trailing separator leaves an empty field",
+			dump: "v0.26.0-",
+			want: "",
+		},
+		{
+			name: "abbreviation shorter than a commit hash is rejected",
+			dump: "v0.26.0-abc",
+			want: "",
+		},
+		{
+			name: "non-hex field of sufficient length is rejected",
+			dump: "v0.26.0-snapshot",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shortCommit(tt.dump); got != tt.want {
+				t.Errorf("shortCommit(%q) = %q, want %q", tt.dump, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsHexString(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"abc1234", true},
+		{"5484F0CC", true},
+		{"", true},
+		{"dirty", false},
+		{"rc1", false},
+		{"beta123", false},
+		{"abc123g", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := isHexString(tt.in); got != tt.want {
+				t.Errorf("isHexString(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`getGitVersion` runs from `Execute` on **every command failure**, so each defect here replaced or
delayed the user's actual error message. Wave 0 of the repository review — the hotfix tier.

### Two panics, not one

```go
commit := strings.Split(VersionWrapDump, "-")
if releaseTag.DATA.SHA[:8] != commit[1] {   // both sides can panic
```

* `commit[1]` — `cmd/tronctl/main.go:53` sets `VersionWrapDump` to the bare version when no commit is
  recorded, so `Split` returns a **single field** and the index is out of range.
* `SHA[:8]` — sliced with no length check.

Both fire while reporting an ordinary error, so a stack trace replaced the real message.

### Untimed HTTP on every error path

Both calls used bare `http.Get`, which has no timeout. A hung endpoint delayed the user's error
indefinitely, and offline use added a network-failure wait to every error. Both requests now share a
single 3s context deadline — not a per-request timeout, which could have stacked to 6s.

### Release builds always reported themselves outdated

A width mismatch. The local commit is **7** characters — from both goreleaser's `{{ .ShortCommit }}`
and the `s.Value[:7]` truncation in `cmd/tronctl/main.go:35` — but the check compared it against
`SHA[:8]`, **8** characters. The two could never be equal, so every release build printed
`Warning: Using outdated version`, training users to ignore the warning. Now compared by prefix.

### Annotated tags

An annotated tag resolves to a tag object, not a commit, so its sha is not comparable with the build
commit. Verified this is **not currently triggered** — `git/ref/tags/v0.26.0` returns
`type: "commit"` because releases are tagged lightweight today. Guarded anyway, since it is one
`git tag -a` away: report the tag rather than warn on a value that was never a commit.

### `shortCommit` scans for a hex field

Taking field `[1]` is correct for `v0.26.0-abc1234` (goreleaser) and `v366-5484f0cc-dirty`
(Makefile), but picks up `"rc1"` from a prerelease tag like `v0.27.0-rc1-abc1234` — reintroducing
exactly the false "outdated" warning this PR removes. Scanning back to front for a hex field of at
least 7 characters is correct for all three shapes.

## Testing

**New:** `cmd/subcommands/root_test.go` — 16 table-driven subtests covering `shortCommit` and
`isHexString`, including the exact `"v0.26.0"` input that panicked, `-dirty` suffixes, prerelease
tags, short abbreviations and non-hex fields.

⚠️ These do **not** run in CI: `make test` excludes `/cmd` (a known finding). Verified locally with
`go test ./cmd/...` — all pass. They begin running automatically when that exclusion is lifted.

`make lint` (0 issues) · `make test` (20/20 packages) · `go test ./cmd/...` · `make` · `go vet` — all clean.

## Note

This PR keeps the version check on the error path. The review also suggests running it **only** for
the `version`/`upgrade` commands rather than on every failure — that is a user-visible behaviour
change (errors would no longer carry the latest tag) and `getGitVersion` has no other caller, so it
would mean deleting the function. Left for a separate decision rather than folded into a hotfix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI version checks with faster timeouts and more reliable release detection.
  * Correctly handles annotated tags and varied version formats.
  * More accurately identifies outdated builds using commit matching.

* **Tests**
  * Added coverage for commit extraction and hexadecimal identifier validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->