### PR TITLE
fix: validate untrusted input before indexing, asserting or dereferencing

### DIFF
--- a/pkg/client/account.go
+++ b/pkg/client/account.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
-	"google.golang.org/protobuf/proto"
 )
 
 // GetAccount from BASE58 address
@@ -111,11 +110,8 @@ func (g *GrpcClient) CreateAccountCtx(ctx context.Context, from, addr string) (*
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "create account"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -141,11 +137,8 @@ func (g *GrpcClient) UpdateAccountCtx(ctx context.Context, from, accountName str
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "update account"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -361,11 +354,8 @@ func (g *GrpcClient) WithdrawBalanceCtx(ctx context.Context, from string) (*api.
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "withdraw balance"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -554,11 +544,8 @@ func (g *GrpcClient) UpdateAccountPermissionCtx(ctx context.Context, from string
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "update account permission"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }

--- a/pkg/client/account.go
+++ b/pkg/client/account.go
@@ -37,6 +37,11 @@ func (g *GrpcClient) GetAccountCtx(ctx context.Context, addr string) (*core.Acco
 	if err != nil {
 		return nil, err
 	}
+	// A substituted WalletClient can return (nil, nil); a real gRPC round trip
+	// always materialises a message. Check before field access.
+	if acc == nil {
+		return nil, fmt.Errorf("account not found")
+	}
 	if !bytes.Equal(acc.Address, account.Address) {
 		return nil, fmt.Errorf("account not found")
 	}

--- a/pkg/client/account.go
+++ b/pkg/client/account.go
@@ -436,7 +436,6 @@ func (g *GrpcClient) UpdateAccountPermission(from string, owner, witness map[str
 	return g.UpdateAccountPermissionCtx(ctx, from, owner, witness, actives)
 }
 
-// UpdateAccountPermissionCtx is the context-aware version of UpdateAccountPermission.
 // permField reads one field from a caller-supplied permission map with a checked
 // assertion. The public API takes map[string]interface{}, so a missing key — or a
 // plain int where int64 was meant — would otherwise panic part-way through a
@@ -454,6 +453,7 @@ func permField[T any](m map[string]interface{}, scope, key string) (T, error) {
 	return t, nil
 }
 
+// UpdateAccountPermissionCtx is the context-aware version of UpdateAccountPermission.
 func (g *GrpcClient) UpdateAccountPermissionCtx(ctx context.Context, from string, owner, witness map[string]interface{}, actives []map[string]interface{}) (*api.TransactionExtention, error) {
 	ctx = g.withAPIKey(ctx)
 

--- a/pkg/client/account.go
+++ b/pkg/client/account.go
@@ -437,6 +437,23 @@ func (g *GrpcClient) UpdateAccountPermission(from string, owner, witness map[str
 }
 
 // UpdateAccountPermissionCtx is the context-aware version of UpdateAccountPermission.
+// permField reads one field from a caller-supplied permission map with a checked
+// assertion. The public API takes map[string]interface{}, so a missing key — or a
+// plain int where int64 was meant — would otherwise panic part-way through a
+// multisig permission update rather than returning an error.
+func permField[T any](m map[string]interface{}, scope, key string) (T, error) {
+	var zero T
+	v, ok := m[key]
+	if !ok {
+		return zero, fmt.Errorf("%s permission: missing %q", scope, key)
+	}
+	t, ok := v.(T)
+	if !ok {
+		return zero, fmt.Errorf("%s permission: %q must be %T, got %T", scope, key, zero, v)
+	}
+	return t, nil
+}
+
 func (g *GrpcClient) UpdateAccountPermissionCtx(ctx context.Context, from string, owner, witness map[string]interface{}, actives []map[string]interface{}) (*api.TransactionExtention, error) {
 	ctx = g.withAPIKey(ctx)
 
@@ -447,13 +464,21 @@ func (g *GrpcClient) UpdateAccountPermissionCtx(ctx context.Context, from string
 	if owner == nil {
 		return nil, fmt.Errorf("owner is mandatory")
 	}
+	ownerThreshold, err := permField[int64](owner, "owner", "threshold")
+	if err != nil {
+		return nil, err
+	}
+	ownerKeys, err := permField[map[string]int64](owner, "owner", "keys")
+	if err != nil {
+		return nil, err
+	}
 	ownerPermission, err := makePermission(
 		"owner",
 		core.Permission_Owner,
 		0,
-		owner["threshold"].(int64),
+		ownerThreshold,
 		nil,
-		owner["keys"].(map[string]int64),
+		ownerKeys,
 	)
 	if err != nil {
 		return nil, err
@@ -469,13 +494,30 @@ func (g *GrpcClient) UpdateAccountPermissionCtx(ctx context.Context, from string
 	if actives != nil {
 		activesPermission := make([]*core.Permission, 0)
 		for i, active := range actives {
+			scope := fmt.Sprintf("active[%d]", i)
+			activeName, err := permField[string](active, scope, "name")
+			if err != nil {
+				return nil, err
+			}
+			activeThreshold, err := permField[int64](active, scope, "threshold")
+			if err != nil {
+				return nil, err
+			}
+			activeOps, err := permField[map[string]bool](active, scope, "operations")
+			if err != nil {
+				return nil, err
+			}
+			activeKeys, err := permField[map[string]int64](active, scope, "keys")
+			if err != nil {
+				return nil, err
+			}
 			activeP, err := makePermission(
-				active["name"].(string),
+				activeName,
 				core.Permission_Active,
 				int32(2+i),
-				active["threshold"].(int64),
-				active["operations"].(map[string]bool),
-				active["keys"].(map[string]int64),
+				activeThreshold,
+				activeOps,
+				activeKeys,
 			)
 			if err != nil {
 				return nil, err
@@ -486,13 +528,21 @@ func (g *GrpcClient) UpdateAccountPermissionCtx(ctx context.Context, from string
 	}
 
 	if witness != nil {
+		witnessThreshold, err := permField[int64](witness, "witness", "threshold")
+		if err != nil {
+			return nil, err
+		}
+		witnessKeys, err := permField[map[string]int64](witness, "witness", "keys")
+		if err != nil {
+			return nil, err
+		}
 		witnessPermission, err := makePermission(
 			"witness",
 			core.Permission_Witness,
 			1,
-			witness["threshold"].(int64),
+			witnessThreshold,
 			nil,
-			witness["keys"].(map[string]int64),
+			witnessKeys,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/client/assets.go
+++ b/pkg/client/assets.go
@@ -9,7 +9,6 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
-	"google.golang.org/protobuf/proto"
 )
 
 // GetAssetIssueByAccount list asset issued by account
@@ -170,11 +169,8 @@ func (g *GrpcClient) AssetIssueCtx(ctx context.Context, from, name, description,
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "asset issue"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -207,11 +203,8 @@ func (g *GrpcClient) UpdateAssetIssueCtx(ctx context.Context, from, description,
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "update asset issue"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -244,11 +237,8 @@ func (g *GrpcClient) TransferAssetCtx(ctx context.Context, from, toAddress,
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "transfer asset"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -281,11 +271,8 @@ func (g *GrpcClient) ParticipateAssetIssueCtx(ctx context.Context, from, issuerA
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "participate asset issue"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -311,11 +298,8 @@ func (g *GrpcClient) UnfreezeAssetCtx(ctx context.Context, from string) (*api.Tr
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "unfreeze asset"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }

--- a/pkg/client/bank.go
+++ b/pkg/client/bank.go
@@ -7,7 +7,6 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
-	"google.golang.org/protobuf/proto"
 )
 
 // FreezeBalance from base58 address
@@ -45,11 +44,8 @@ func (g *GrpcClient) FreezeBalanceCtx(ctx context.Context, from, delegateTo stri
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "freeze balance"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -85,11 +81,8 @@ func (g *GrpcClient) FreezeBalanceV2Ctx(ctx context.Context, from string,
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "freeze balance v2"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -124,11 +117,8 @@ func (g *GrpcClient) UnfreezeBalanceCtx(ctx context.Context, from, delegateTo st
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "unfreeze balance"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -162,11 +152,8 @@ func (g *GrpcClient) UnfreezeBalanceV2Ctx(ctx context.Context, from string, reso
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "unfreeze balance v2"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -246,16 +233,8 @@ func (g *GrpcClient) WithdrawExpireUnfreezeCtx(ctx context.Context, from string,
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
-	}
-	// A success code does not guarantee a transaction: guard before callers
-	// sign or read RawData (same shape as triggerContract / DeployContractCtx).
-	if tx.GetTransaction().GetRawData() == nil {
-		return nil, fmt.Errorf("withdraw expire unfreeze: node returned no transaction")
+	if err := requireTxExtension(tx, "withdraw expire unfreeze"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }

--- a/pkg/client/bank.go
+++ b/pkg/client/bank.go
@@ -252,5 +252,10 @@ func (g *GrpcClient) WithdrawExpireUnfreezeCtx(ctx context.Context, from string,
 	if tx.GetResult().GetCode() != 0 {
 		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
 	}
+	// A success code does not guarantee a transaction: guard before callers
+	// sign or read RawData (same shape as triggerContract / DeployContractCtx).
+	if tx.GetTransaction().GetRawData() == nil {
+		return nil, fmt.Errorf("withdraw expire unfreeze: node returned no transaction")
+	}
 	return tx, nil
 }

--- a/pkg/client/bank.go
+++ b/pkg/client/bank.go
@@ -249,5 +249,8 @@ func (g *GrpcClient) WithdrawExpireUnfreezeCtx(ctx context.Context, from string,
 	if proto.Size(tx) == 0 {
 		return nil, fmt.Errorf("bad transaction")
 	}
+	if tx.GetResult().GetCode() != 0 {
+		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	}
 	return tx, nil
 }

--- a/pkg/client/contracts.go
+++ b/pkg/client/contracts.go
@@ -94,8 +94,8 @@ func (g *GrpcClient) UpdateEnergyLimitContractCtx(ctx context.Context, from, con
 		return nil, err
 	}
 
-	if tx.Result.Code > 0 {
-		return nil, fmt.Errorf("%s", string(tx.Result.Message))
+	if tx.GetResult().GetCode() > 0 {
+		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
 	}
 
 	return tx, err
@@ -133,8 +133,8 @@ func (g *GrpcClient) UpdateSettingContractCtx(ctx context.Context, from, contrac
 		return nil, err
 	}
 
-	if tx.Result.Code > 0 {
-		return nil, fmt.Errorf("%s", string(tx.Result.Message))
+	if tx.GetResult().GetCode() > 0 {
+		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
 	}
 
 	return tx, err
@@ -248,8 +248,13 @@ func (g *GrpcClient) triggerContract(ctx context.Context, ct *core.TriggerSmartC
 		return nil, err
 	}
 
-	if tx.Result.Code > 0 {
-		return nil, fmt.Errorf("%s", string(tx.Result.Message))
+	if tx.GetResult().GetCode() > 0 {
+		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
+	}
+	// A success code does not guarantee a transaction: guard before assigning
+	// through it, as DeployContractCtx does.
+	if tx.GetTransaction().GetRawData() == nil {
+		return nil, fmt.Errorf("trigger contract: node returned no transaction")
 	}
 	if feeLimit > 0 {
 		tx.Transaction.RawData.FeeLimit = feeLimit
@@ -446,8 +451,8 @@ func (g *GrpcClient) estimateEnergy(ctx context.Context, ct *core.TriggerSmartCo
 		return nil, err
 	}
 
-	if tx.Result.Code > 0 {
-		return nil, fmt.Errorf("%s", string(tx.Result.Message))
+	if tx.GetResult().GetCode() > 0 {
+		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
 	}
 
 	return tx, err
@@ -504,6 +509,15 @@ func (g *GrpcClient) DeployContractCtx(ctx context.Context, from, contractName s
 	tx, err := g.Client.DeployContract(ctx, ct)
 	if err != nil {
 		return nil, err
+	}
+	// A rejected deployment comes back with a nil gRPC error, a non-zero result
+	// code and no Transaction, so the fee-limit assignment below would panic
+	// instead of surfacing the node's reason for the rejection.
+	if tx.GetResult().GetCode() != 0 {
+		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	}
+	if tx.GetTransaction().GetRawData() == nil {
+		return nil, fmt.Errorf("deploy contract: node returned no transaction")
 	}
 	if feeLimit > 0 {
 		tx.Transaction.RawData.FeeLimit = feeLimit

--- a/pkg/client/contracts.go
+++ b/pkg/client/contracts.go
@@ -93,12 +93,10 @@ func (g *GrpcClient) UpdateEnergyLimitContractCtx(ctx context.Context, from, con
 	if err != nil {
 		return nil, err
 	}
-
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
+	if err := requireTxExtension(tx, "update energy limit"); err != nil {
+		return nil, err
 	}
-
-	return tx, err
+	return tx, nil
 }
 
 // UpdateSettingContract changes the user resource consumption ratio of a deployed contract.
@@ -132,12 +130,10 @@ func (g *GrpcClient) UpdateSettingContractCtx(ctx context.Context, from, contrac
 	if err != nil {
 		return nil, err
 	}
-
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
+	if err := requireTxExtension(tx, "update setting"); err != nil {
+		return nil, err
 	}
-
-	return tx, err
+	return tx, nil
 }
 
 // TriggerConstantContract executes a read-only smart contract call and returns the result.
@@ -248,13 +244,8 @@ func (g *GrpcClient) triggerContract(ctx context.Context, ct *core.TriggerSmartC
 		return nil, err
 	}
 
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
-	}
-	// A success code does not guarantee a transaction: guard before assigning
-	// through it, as DeployContractCtx does.
-	if tx.GetTransaction().GetRawData() == nil {
-		return nil, fmt.Errorf("trigger contract: node returned no transaction")
+	if err := requireTxExtension(tx, "trigger contract"); err != nil {
+		return nil, err
 	}
 	if feeLimit > 0 {
 		tx.Transaction.RawData.FeeLimit = feeLimit
@@ -513,11 +504,8 @@ func (g *GrpcClient) DeployContractCtx(ctx context.Context, from, contractName s
 	// A rejected deployment comes back with a nil gRPC error, a non-zero result
 	// code and no Transaction, so the fee-limit assignment below would panic
 	// instead of surfacing the node's reason for the rejection.
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
-	}
-	if tx.GetTransaction().GetRawData() == nil {
-		return nil, fmt.Errorf("deploy contract: node returned no transaction")
+	if err := requireTxExtension(tx, "deploy contract"); err != nil {
+		return nil, err
 	}
 	if feeLimit > 0 {
 		tx.Transaction.RawData.FeeLimit = feeLimit

--- a/pkg/client/contracts.go
+++ b/pkg/client/contracts.go
@@ -94,7 +94,7 @@ func (g *GrpcClient) UpdateEnergyLimitContractCtx(ctx context.Context, from, con
 		return nil, err
 	}
 
-	if tx.GetResult().GetCode() > 0 {
+	if tx.GetResult().GetCode() != 0 {
 		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
 	}
 
@@ -133,7 +133,7 @@ func (g *GrpcClient) UpdateSettingContractCtx(ctx context.Context, from, contrac
 		return nil, err
 	}
 
-	if tx.GetResult().GetCode() > 0 {
+	if tx.GetResult().GetCode() != 0 {
 		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
 	}
 
@@ -248,7 +248,7 @@ func (g *GrpcClient) triggerContract(ctx context.Context, ct *core.TriggerSmartC
 		return nil, err
 	}
 
-	if tx.GetResult().GetCode() > 0 {
+	if tx.GetResult().GetCode() != 0 {
 		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
 	}
 	// A success code does not guarantee a transaction: guard before assigning
@@ -451,7 +451,7 @@ func (g *GrpcClient) estimateEnergy(ctx context.Context, ct *core.TriggerSmartCo
 		return nil, err
 	}
 
-	if tx.GetResult().GetCode() > 0 {
+	if tx.GetResult().GetCode() != 0 {
 		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
 	}
 

--- a/pkg/client/contracts.go
+++ b/pkg/client/contracts.go
@@ -441,12 +441,19 @@ func (g *GrpcClient) estimateEnergy(ctx context.Context, ct *core.TriggerSmartCo
 		}
 		return nil, err
 	}
-
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
+	// A substituted WalletClient can return (nil, nil); treat that as empty.
+	if tx == nil {
+		return nil, fmt.Errorf("estimate energy: empty response from node")
+	}
+	if code := tx.GetResult().GetCode(); code != 0 {
+		msg := string(tx.GetResult().GetMessage())
+		if msg == "" {
+			return nil, fmt.Errorf("estimate energy: node rejected request: code=%v", code)
+		}
+		return nil, fmt.Errorf("%s", msg)
 	}
 
-	return tx, err
+	return tx, nil
 }
 
 // DeployContract deploys a new smart contract and returns the unsigned transaction.

--- a/pkg/client/exchange.go
+++ b/pkg/client/exchange.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
-	"google.golang.org/protobuf/proto"
 )
 
 // ExchangeList of bancor TRC10, use page -1 to list all
@@ -97,11 +96,8 @@ func (g *GrpcClient) ExchangeCreateCtx(
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "exchange create"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -143,11 +139,8 @@ func (g *GrpcClient) ExchangeInjectCtx(
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "exchange inject"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -189,11 +182,8 @@ func (g *GrpcClient) ExchangeWithdrawCtx(
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "exchange withdraw"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -238,11 +228,8 @@ func (g *GrpcClient) ExchangeTradeCtx(
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "exchange trade"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }

--- a/pkg/client/network.go
+++ b/pkg/client/network.go
@@ -106,7 +106,10 @@ func (g *GrpcClient) GetTransactionInfoByIDCtx(ctx context.Context, id string) (
 	if err != nil {
 		return nil, err
 	}
-	if bytes.Equal(txi.Id, transactionID.Value) {
+	if txi == nil {
+		return nil, fmt.Errorf("transaction info not found: empty response from node")
+	}
+	if bytes.Equal(txi.GetId(), transactionID.Value) {
 		return txi, nil
 	}
 	return nil, fmt.Errorf("transaction info not found")

--- a/pkg/client/proposal.go
+++ b/pkg/client/proposal.go
@@ -2,12 +2,10 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
-	"google.golang.org/protobuf/proto"
 )
 
 // ProposalsList return all network proposals
@@ -47,11 +45,8 @@ func (g *GrpcClient) ProposalCreateCtx(ctx context.Context, from string, paramet
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "proposal create"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -81,11 +76,8 @@ func (g *GrpcClient) ProposalApproveCtx(ctx context.Context, from string, id int
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "proposal approve"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -114,11 +106,8 @@ func (g *GrpcClient) ProposalWithdrawCtx(ctx context.Context, from string, id in
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "proposal withdraw"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }

--- a/pkg/client/resources.go
+++ b/pkg/client/resources.go
@@ -213,6 +213,11 @@ func (g *GrpcClient) DelegateResourceCtx(ctx context.Context, from, to string, r
 	if response.GetResult().GetCode() != 0 {
 		return nil, fmt.Errorf("%s", response.GetResult().GetMessage())
 	}
+	// A success code does not guarantee a transaction: guard before callers
+	// sign or read RawData (same shape as triggerContract / DeployContractCtx).
+	if response.GetTransaction().GetRawData() == nil {
+		return nil, fmt.Errorf("delegate resource: node returned no transaction")
+	}
 
 	return response, nil
 }
@@ -255,6 +260,9 @@ func (g *GrpcClient) UnDelegateResourceCtx(ctx context.Context, owner, receiver 
 	}
 	if response.GetResult().GetCode() != 0 {
 		return nil, fmt.Errorf("%s", response.GetResult().GetMessage())
+	}
+	if response.GetTransaction().GetRawData() == nil {
+		return nil, fmt.Errorf("undelegate resource: node returned no transaction")
 	}
 
 	return response, nil

--- a/pkg/client/resources.go
+++ b/pkg/client/resources.go
@@ -2,12 +2,10 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
-	"google.golang.org/protobuf/proto"
 )
 
 // GetAccountResource from BASE58 address
@@ -207,16 +205,8 @@ func (g *GrpcClient) DelegateResourceCtx(ctx context.Context, from, to string, r
 		return nil, err
 
 	}
-	if proto.Size(response) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if response.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", response.GetResult().GetMessage())
-	}
-	// A success code does not guarantee a transaction: guard before callers
-	// sign or read RawData (same shape as triggerContract / DeployContractCtx).
-	if response.GetTransaction().GetRawData() == nil {
-		return nil, fmt.Errorf("delegate resource: node returned no transaction")
+	if err := requireTxExtension(response, "delegate resource"); err != nil {
+		return nil, err
 	}
 
 	return response, nil
@@ -255,14 +245,8 @@ func (g *GrpcClient) UnDelegateResourceCtx(ctx context.Context, owner, receiver 
 		return nil, err
 
 	}
-	if proto.Size(response) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if response.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", response.GetResult().GetMessage())
-	}
-	if response.GetTransaction().GetRawData() == nil {
-		return nil, fmt.Errorf("undelegate resource: node returned no transaction")
+	if err := requireTxExtension(response, "undelegate resource"); err != nil {
+		return nil, err
 	}
 
 	return response, nil

--- a/pkg/client/resources.go
+++ b/pkg/client/resources.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+	"google.golang.org/protobuf/proto"
 )
 
 // GetAccountResource from BASE58 address
@@ -205,6 +207,12 @@ func (g *GrpcClient) DelegateResourceCtx(ctx context.Context, from, to string, r
 		return nil, err
 
 	}
+	if proto.Size(response) == 0 {
+		return nil, fmt.Errorf("bad transaction")
+	}
+	if response.GetResult().GetCode() != 0 {
+		return nil, fmt.Errorf("%s", response.GetResult().GetMessage())
+	}
 
 	return response, nil
 }
@@ -241,6 +249,12 @@ func (g *GrpcClient) UnDelegateResourceCtx(ctx context.Context, owner, receiver 
 	if err != nil {
 		return nil, err
 
+	}
+	if proto.Size(response) == 0 {
+		return nil, fmt.Errorf("bad transaction")
+	}
+	if response.GetResult().GetCode() != 0 {
+		return nil, fmt.Errorf("%s", response.GetResult().GetMessage())
 	}
 
 	return response, nil

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -2,12 +2,10 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
-	"google.golang.org/protobuf/proto"
 )
 
 // Transfer from to base58 address
@@ -35,11 +33,8 @@ func (g *GrpcClient) TransferCtx(ctx context.Context, from, toAddress string, am
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "transfer"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }

--- a/pkg/client/trc20.go
+++ b/pkg/client/trc20.go
@@ -95,8 +95,12 @@ func (g *GrpcClient) TRC20CallCtx(ctx context.Context, from, contractAddress, da
 	if err != nil {
 		return nil, err
 	}
+	// Return nil rather than the rejection payload, matching triggerContract and
+	// DeployContractCtx. TRC20Send, TRC20Approve and TRC20TransferFrom return this
+	// value straight through, so handing back a rejected TransactionExtention lets
+	// a caller that checks the result before the error sign and broadcast it.
 	if result.GetResult().GetCode() > 0 {
-		return result, fmt.Errorf("%s", string(result.GetResult().GetMessage()))
+		return nil, fmt.Errorf("%s", string(result.GetResult().GetMessage()))
 	}
 	return result, nil
 

--- a/pkg/client/trc20.go
+++ b/pkg/client/trc20.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+	"github.com/fbsobreira/gotron-sdk/pkg/standards/trc20enc"
 )
 
 // TRC20Option configures optional behaviour on TRC20 write methods
@@ -94,11 +95,31 @@ func (g *GrpcClient) TRC20CallCtx(ctx context.Context, from, contractAddress, da
 	if err != nil {
 		return nil, err
 	}
-	if result.Result.Code > 0 {
-		return result, fmt.Errorf("%s", string(result.Result.Message))
+	if result.GetResult().GetCode() > 0 {
+		return result, fmt.Errorf("%s", string(result.GetResult().GetMessage()))
 	}
 	return result, nil
 
+}
+
+// constantResultHex returns the first constant_result entry of a read-only call
+// as a hex string.
+//
+// The node controls this slice, and a response can carry a success code while
+// still containing no entries, so it is length-checked before indexing. The
+// entry must also hold at least one full ABI word: every constant result is
+// 32-byte aligned, so a shorter one is malformed, and rejecting it here gives a
+// clear error instead of a confusing parse failure further down. This mirrors
+// the guard in callForAddress (contracts.go).
+func constantResultHex(result *api.TransactionExtention) (string, error) {
+	if len(result.GetConstantResult()) == 0 {
+		return "", fmt.Errorf("node returned no constant result")
+	}
+	if len(result.GetConstantResult()[0]) < 32 {
+		return "", fmt.Errorf("node returned a %d-byte constant result, expected at least 32",
+			len(result.GetConstantResult()[0]))
+	}
+	return common.BytesToHexString(result.GetConstantResult()[0]), nil
 }
 
 // TRC20GetName returns the name of a TRC20 token contract.
@@ -116,7 +137,10 @@ func (g *GrpcClient) TRC20GetNameCtx(ctx context.Context, contractAddress string
 	if err != nil {
 		return "", err
 	}
-	data := common.BytesToHexString(result.GetConstantResult()[0])
+	data, err := constantResultHex(result)
+	if err != nil {
+		return "", err
+	}
 	return g.ParseTRC20StringProperty(data)
 }
 
@@ -135,7 +159,10 @@ func (g *GrpcClient) TRC20GetSymbolCtx(ctx context.Context, contractAddress stri
 	if err != nil {
 		return "", err
 	}
-	data := common.BytesToHexString(result.GetConstantResult()[0])
+	data, err := constantResultHex(result)
+	if err != nil {
+		return "", err
+	}
 	return g.ParseTRC20StringProperty(data)
 }
 
@@ -154,7 +181,10 @@ func (g *GrpcClient) TRC20GetDecimalsCtx(ctx context.Context, contractAddress st
 	if err != nil {
 		return nil, err
 	}
-	data := common.BytesToHexString(result.GetConstantResult()[0])
+	data, err := constantResultHex(result)
+	if err != nil {
+		return nil, err
+	}
 	return g.ParseTRC20NumericProperty(data)
 }
 
@@ -185,9 +215,14 @@ func (g *GrpcClient) ParseTRC20StringProperty(data string) (string, error) {
 	}
 	if len(data) > 128 {
 		n, _ := g.ParseTRC20NumericProperty(data[64:128])
-		if n != nil {
+		// l is the ABI string length, taken from contract-controlled return data.
+		// Reject anything that does not fit in a uint64 — Uint64 would silently
+		// return the low 64 bits — then bound it by division rather than by
+		// comparing 2*l. The original 2*int(l) overflowed to a negative value for
+		// l >= 2^62, passing the check and panicking on the slice below.
+		if n != nil && n.IsUint64() {
 			l := n.Uint64()
-			if 2*int(l) <= len(data)-128 {
+			if l <= uint64(len(data)-128)/2 {
 				b, err := hex.DecodeString(data[128 : 128+2*l])
 				if err == nil {
 					return string(b), nil
@@ -232,7 +267,10 @@ func (g *GrpcClient) TRC20ContractBalanceCtx(ctx context.Context, addr, contract
 	if err != nil {
 		return nil, err
 	}
-	data := common.BytesToHexString(result.GetConstantResult()[0])
+	data, err := constantResultHex(result)
+	if err != nil {
+		return nil, err
+	}
 	r, err := g.ParseTRC20NumericProperty(data)
 	if err != nil {
 		return nil, fmt.Errorf("contract address %s: %v", contractAddress, err)
@@ -259,7 +297,10 @@ func (g *GrpcClient) TRC20SendCtx(ctx context.Context, from, to, contract string
 	if err != nil {
 		return nil, err
 	}
-	ab := common.LeftPadBytes(amount.Bytes(), 32)
+	ab, err := trc20enc.PadUint256(amount)
+	if err != nil {
+		return nil, fmt.Errorf("invalid amount: %w", err)
+	}
 	req := trc20TransferMethodSignature + "0000000000000000000000000000000000000000000000000000000000000000"[len(addrB.Hex())-4:] + addrB.Hex()[4:]
 	req += common.Bytes2Hex(ab)
 	return g.TRC20CallCtx(ctx, from, contract, req, cfg.estimate, feeLimit)
@@ -288,7 +329,10 @@ func (g *GrpcClient) TRC20TransferFromCtx(ctx context.Context, owner, from, to, 
 	if err != nil {
 		return nil, err
 	}
-	ab := common.LeftPadBytes(amount.Bytes(), 32)
+	ab, err := trc20enc.PadUint256(amount)
+	if err != nil {
+		return nil, fmt.Errorf("invalid amount: %w", err)
+	}
 	req := "0x23b872dd" +
 		"0000000000000000000000000000000000000000000000000000000000000000"[len(addrA.Hex())-4:] + addrA.Hex()[4:] +
 		"0000000000000000000000000000000000000000000000000000000000000000"[len(addrB.Hex())-4:] + addrB.Hex()[4:]
@@ -312,7 +356,10 @@ func (g *GrpcClient) TRC20ApproveCtx(ctx context.Context, from, to, contract str
 	if err != nil {
 		return nil, err
 	}
-	ab := common.LeftPadBytes(amount.Bytes(), 32)
+	ab, err := trc20enc.PadUint256(amount)
+	if err != nil {
+		return nil, fmt.Errorf("invalid amount: %w", err)
+	}
 	req := trc20ApproveMethodSignature + "0000000000000000000000000000000000000000000000000000000000000000"[len(addrB.Hex())-4:] + addrB.Hex()[4:]
 	req += common.Bytes2Hex(ab)
 	return g.TRC20CallCtx(ctx, from, contract, req, cfg.estimate, feeLimit)

--- a/pkg/client/trc20.go
+++ b/pkg/client/trc20.go
@@ -95,11 +95,16 @@ func (g *GrpcClient) TRC20CallCtx(ctx context.Context, from, contractAddress, da
 	if err != nil {
 		return nil, err
 	}
-	// Return nil rather than the rejection payload, matching triggerContract and
-	// DeployContractCtx. TRC20Send, TRC20Approve and TRC20TransferFrom return this
-	// value straight through, so handing back a rejected TransactionExtention lets
-	// a caller that checks the result before the error sign and broadcast it.
-	if result.GetResult().GetCode() > 0 {
+	// Write path: triggerContract already rejects non-zero codes and requires
+	// RawData, so a rejected extension never reaches callers. Constant path:
+	// some nodes omit Result or set Result=false while still returning a
+	// well-formed constant_result. Accept that (GetCode on a nil Result is 0)
+	// and only reject a non-zero code; constantResultHex validates the payload.
+	// That is deliberately weaker than callForAddress, which requires
+	// Result != nil && Result && Code == 0 because it returns "" on any
+	// failure rather than propagating an error. TRC20Send/Approve/TransferFrom
+	// pass this value straight through, so never return a rejected extension.
+	if result.GetResult().GetCode() != 0 {
 		return nil, fmt.Errorf("%s", string(result.GetResult().GetMessage()))
 	}
 	return result, nil

--- a/pkg/client/trc20_test.go
+++ b/pkg/client/trc20_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strings"
 	"testing"
 
 	client "github.com/fbsobreira/gotron-sdk/pkg/client"
@@ -312,6 +313,41 @@ func TestParseTRC20StringProperty(t *testing.T) {
 	t.Run("empty data", func(t *testing.T) {
 		_, err := c.ParseTRC20StringProperty("")
 		require.Error(t, err)
+	})
+
+	// A hostile token contract controls the declared string length, which reaches
+	// here from TRC20GetName and TRC20GetSymbol. Each length below broke the old
+	// bounds check in one of two ways, both verified against the original code:
+	//
+	//	panic         2*int(l) overflowed to a negative value, so the check passed
+	//	              and the slice then ran with a huge upper bound.
+	//	silent empty  Uint64 truncated a >64-bit length to its low bits, or 2*l
+	//	              wrapped to exactly 0, yielding "" with a nil error.
+	//
+	// Both are now rejected: IsUint64 catches the truncation, and the bound is a
+	// division so no multiplication can overflow.
+	t.Run("hostile declared length", func(t *testing.T) {
+		lengthWord := func(v string) string { return strings.Repeat("0", 64-len(v)) + v }
+		for _, tc := range []struct {
+			name, length, oldBehaviour string
+		}{
+			{"2^62", lengthWord("4000000000000000"), "panic"},
+			{"2^63", lengthWord("8000000000000000"), "silent empty"},
+			{"max uint64", lengthWord("ffffffffffffffff"), "panic"},
+			{"2^254", "4" + strings.Repeat("0", 63), "silent empty"},
+			{"max uint256", strings.Repeat("f", 64), "panic"},
+			{"exceeds payload", lengthWord("40"), "correctly rejected"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				data := "0000000000000000000000000000000000000000000000000000000000000020" +
+					tc.length +
+					"48656c6c6f000000000000000000000000000000000000000000000000000000"
+				require.NotPanics(t, func() {
+					_, err := c.ParseTRC20StringProperty(data)
+					require.Error(t, err, "old behaviour here was: %s", tc.oldBehaviour)
+				})
+			})
+		}
 	})
 }
 

--- a/pkg/client/txext.go
+++ b/pkg/client/txext.go
@@ -19,8 +19,15 @@ func requireTxExtension(tx *api.TransactionExtention, op string) error {
 	if tx == nil || proto.Size(tx) == 0 {
 		return fmt.Errorf("bad transaction")
 	}
-	if tx.GetResult().GetCode() != 0 {
-		return fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
+	if code := tx.GetResult().GetCode(); code != 0 {
+		msg := string(tx.GetResult().GetMessage())
+		if msg == "" {
+			if op == "" {
+				return fmt.Errorf("node rejected request: code=%v", code)
+			}
+			return fmt.Errorf("%s: node rejected request: code=%v", op, code)
+		}
+		return fmt.Errorf("%s", msg)
 	}
 	if tx.GetTransaction().GetRawData() == nil {
 		if op == "" {

--- a/pkg/client/txext.go
+++ b/pkg/client/txext.go
@@ -1,0 +1,32 @@
+package client
+
+import (
+	"fmt"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
+	"google.golang.org/protobuf/proto"
+)
+
+// requireTxExtension validates a node-built TransactionExtention for write paths.
+//
+// A real full node typically returns either SUCCESS with a full Transaction body,
+// or a non-zero result code with no Transaction. Builders also reject SUCCESS with
+// a missing body so callers never receive a hollow extension to sign (custom
+// WalletClient stubs and partial responses can produce that shape).
+//
+// op is a short name used in the missing-transaction error (e.g. "delegate resource").
+func requireTxExtension(tx *api.TransactionExtention, op string) error {
+	if tx == nil || proto.Size(tx) == 0 {
+		return fmt.Errorf("bad transaction")
+	}
+	if tx.GetResult().GetCode() != 0 {
+		return fmt.Errorf("%s", string(tx.GetResult().GetMessage()))
+	}
+	if tx.GetTransaction().GetRawData() == nil {
+		if op == "" {
+			return fmt.Errorf("node returned no transaction")
+		}
+		return fmt.Errorf("%s: node returned no transaction", op)
+	}
+	return nil
+}

--- a/pkg/client/txext.go
+++ b/pkg/client/txext.go
@@ -19,6 +19,15 @@ func requireTxExtension(tx *api.TransactionExtention, op string) error {
 	if tx == nil || proto.Size(tx) == 0 {
 		return fmt.Errorf("bad transaction")
 	}
+	// GetCode() on a nil *Return returns SUCCESS (proto zero value). That is a
+	// client default, not a node-reported success: full nodes always set Result.
+	// Reject an absent Result so a response with only RawData cannot pass.
+	if tx.GetResult() == nil {
+		if op == "" {
+			return fmt.Errorf("node returned no result")
+		}
+		return fmt.Errorf("%s: node returned no result", op)
+	}
 	if code := tx.GetResult().GetCode(); code != 0 {
 		msg := string(tx.GetResult().GetMessage())
 		if msg == "" {

--- a/pkg/client/txext_test.go
+++ b/pkg/client/txext_test.go
@@ -84,4 +84,25 @@ func TestRequireTxExtension(t *testing.T) {
 		}
 		require.NoError(t, requireTxExtension(tx, "transfer"))
 	})
+
+	// GetCode() on a nil *Return returns SUCCESS, so RawData alone previously
+	// passed validation. Full nodes always set Result; reject the hollow shape.
+	t.Run("nil result with raw data", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Transaction: &core.Transaction{
+				RawData: &core.TransactionRaw{},
+			},
+		}
+		err := requireTxExtension(tx, "transfer")
+		require.ErrorContains(t, err, "node returned no result")
+	})
+
+	t.Run("nil result with raw data empty op", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Transaction: &core.Transaction{
+				RawData: &core.TransactionRaw{},
+			},
+		}
+		require.EqualError(t, requireTxExtension(tx, ""), "node returned no result")
+	})
 }

--- a/pkg/client/txext_test.go
+++ b/pkg/client/txext_test.go
@@ -1,0 +1,58 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequireTxExtension(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		require.ErrorContains(t, requireTxExtension(nil, "op"), "bad transaction")
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		require.ErrorContains(t, requireTxExtension(&api.TransactionExtention{}, "op"), "bad transaction")
+	})
+
+	t.Run("non-zero code", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Result: &api.Return{
+				Result:  false,
+				Code:    api.Return_CONTRACT_VALIDATE_ERROR,
+				Message: []byte("node refused the request"),
+			},
+		}
+		err := requireTxExtension(tx, "delegate resource")
+		require.ErrorContains(t, err, "node refused the request")
+	})
+
+	t.Run("success without transaction", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Result: &api.Return{Result: true, Code: api.Return_SUCCESS},
+		}
+		err := requireTxExtension(tx, "delegate resource")
+		require.ErrorContains(t, err, "delegate resource: node returned no transaction")
+	})
+
+	t.Run("success without raw data", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Result:      &api.Return{Result: true, Code: api.Return_SUCCESS},
+			Transaction: &core.Transaction{},
+		}
+		err := requireTxExtension(tx, "transfer")
+		require.ErrorContains(t, err, "transfer: node returned no transaction")
+	})
+
+	t.Run("success with raw data", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Result: &api.Return{Result: true, Code: api.Return_SUCCESS},
+			Transaction: &core.Transaction{
+				RawData: &core.TransactionRaw{},
+			},
+		}
+		require.NoError(t, requireTxExtension(tx, "transfer"))
+	})
+}

--- a/pkg/client/txext_test.go
+++ b/pkg/client/txext_test.go
@@ -29,6 +29,18 @@ func TestRequireTxExtension(t *testing.T) {
 		require.ErrorContains(t, err, "node refused the request")
 	})
 
+	t.Run("non-zero code empty message", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Result: &api.Return{
+				Result: false,
+				Code:   api.Return_CONTRACT_VALIDATE_ERROR,
+			},
+		}
+		err := requireTxExtension(tx, "transfer")
+		require.ErrorContains(t, err, "node rejected request")
+		require.ErrorContains(t, err, "CONTRACT_VALIDATE_ERROR")
+	})
+
 	t.Run("success without transaction", func(t *testing.T) {
 		tx := &api.TransactionExtention{
 			Result: &api.Return{Result: true, Code: api.Return_SUCCESS},

--- a/pkg/client/txext_test.go
+++ b/pkg/client/txext_test.go
@@ -41,6 +41,23 @@ func TestRequireTxExtension(t *testing.T) {
 		require.ErrorContains(t, err, "CONTRACT_VALIDATE_ERROR")
 	})
 
+	t.Run("non-zero code empty message empty op", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Result: &api.Return{Result: false, Code: api.Return_CONTRACT_VALIDATE_ERROR},
+		}
+		err := requireTxExtension(tx, "")
+		require.ErrorContains(t, err, "node rejected request")
+		require.NotContains(t, err.Error(), ": node rejected")
+	})
+
+	t.Run("success without transaction empty op", func(t *testing.T) {
+		tx := &api.TransactionExtention{
+			Result: &api.Return{Result: true, Code: api.Return_SUCCESS},
+		}
+		err := requireTxExtension(tx, "")
+		require.EqualError(t, err, "node returned no transaction")
+	})
+
 	t.Run("success without transaction", func(t *testing.T) {
 		tx := &api.TransactionExtention{
 			Result: &api.Return{Result: true, Code: api.Return_SUCCESS},

--- a/pkg/client/untrusted_input_test.go
+++ b/pkg/client/untrusted_input_test.go
@@ -153,11 +153,20 @@ func rejectedTx() *api.TransactionExtention {
 	}
 }
 
+// successNoTx is a success-shaped TransactionExtention with no Transaction body.
+// A node (or a custom WalletClient) can return this; callers that only check the
+// result code would otherwise nil-dereference when signing or reading RawData.
+func successNoTx() *api.TransactionExtention {
+	return &api.TransactionExtention{
+		Result: &api.Return{Result: true, Code: api.Return_SUCCESS},
+	}
+}
+
 // These builders previously returned the rejection as an apparently valid
 // TransactionExtention, so the failure surfaced only after signing and
-// broadcast — or not at all.
+// broadcast — or not at all. They must also reject success-with-no-tx.
 func TestBuilders_SurfaceNodeRejection(t *testing.T) {
-	t.Run("WithdrawExpireUnfreeze", func(t *testing.T) {
+	t.Run("WithdrawExpireUnfreeze/non-zero code", func(t *testing.T) {
 		c := newMockClient(t, &mockWalletServer{
 			WithdrawExpireUnfreezeFunc: func(_ context.Context, _ *core.WithdrawExpireUnfreezeContract) (*api.TransactionExtention, error) {
 				return rejectedTx(), nil
@@ -166,8 +175,19 @@ func TestBuilders_SurfaceNodeRejection(t *testing.T) {
 		_, err := c.WithdrawExpireUnfreeze(testAddrA, 1700000000000)
 		require.ErrorContains(t, err, "node refused the request")
 	})
+	t.Run("WithdrawExpireUnfreeze/success no transaction", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			WithdrawExpireUnfreezeFunc: func(_ context.Context, _ *core.WithdrawExpireUnfreezeContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.WithdrawExpireUnfreeze(testAddrA, 1700000000000)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
 
-	t.Run("DelegateResource", func(t *testing.T) {
+	t.Run("DelegateResource/non-zero code", func(t *testing.T) {
 		c := newMockClient(t, &mockWalletServer{
 			DelegateResourceFunc: func(_ context.Context, _ *core.DelegateResourceContract) (*api.TransactionExtention, error) {
 				return rejectedTx(), nil
@@ -176,8 +196,19 @@ func TestBuilders_SurfaceNodeRejection(t *testing.T) {
 		_, err := c.DelegateResource(testAddrA, testAddrB, core.ResourceCode_BANDWIDTH, 1_000_000, false, 0)
 		require.ErrorContains(t, err, "node refused the request")
 	})
+	t.Run("DelegateResource/success no transaction", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			DelegateResourceFunc: func(_ context.Context, _ *core.DelegateResourceContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.DelegateResource(testAddrA, testAddrB, core.ResourceCode_BANDWIDTH, 1_000_000, false, 0)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
 
-	t.Run("UnDelegateResource", func(t *testing.T) {
+	t.Run("UnDelegateResource/non-zero code", func(t *testing.T) {
 		c := newMockClient(t, &mockWalletServer{
 			UnDelegateResourceFunc: func(_ context.Context, _ *core.UnDelegateResourceContract) (*api.TransactionExtention, error) {
 				return rejectedTx(), nil
@@ -185,6 +216,17 @@ func TestBuilders_SurfaceNodeRejection(t *testing.T) {
 		})
 		_, err := c.UnDelegateResource(testAddrA, testAddrB, core.ResourceCode_BANDWIDTH, 1_000_000)
 		require.ErrorContains(t, err, "node refused the request")
+	})
+	t.Run("UnDelegateResource/success no transaction", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			UnDelegateResourceFunc: func(_ context.Context, _ *core.UnDelegateResourceContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.UnDelegateResource(testAddrA, testAddrB, core.ResourceCode_BANDWIDTH, 1_000_000)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
 	})
 }
 
@@ -206,14 +248,70 @@ func TestDeployContract_NodeRejection(t *testing.T) {
 	t.Run("success code but no transaction", func(t *testing.T) {
 		c := newMockClient(t, &mockWalletServer{
 			DeployContractFunc: func(_ context.Context, _ *core.CreateSmartContract) (*api.TransactionExtention, error) {
-				return &api.TransactionExtention{
-					Result: &api.Return{Result: true, Code: api.Return_SUCCESS},
-				}, nil
+				return successNoTx(), nil
 			},
 		})
 		require.NotPanics(t, func() {
 			_, err := c.DeployContract(testAddrA, "Test", &core.SmartContract_ABI{}, "6080", 100, 50, 10000)
-			require.Error(t, err)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+}
+
+// triggerContract (and TRC20 writes that go through it) must surface node
+// rejection and success-with-no-RawData as errors, never as a signable tx.
+func TestTriggerContract_NodeRejection(t *testing.T) {
+	t.Run("TRC20Send/non-zero result code", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			TriggerContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+				return rejectedTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			tx, err := c.TRC20Send(testAddrA, testAddrB, testContract, big.NewInt(1), 100)
+			require.ErrorContains(t, err, "node refused the request")
+			require.Nil(t, tx)
+		})
+	})
+
+	t.Run("TRC20Send/success no transaction", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			TriggerContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			tx, err := c.TRC20Send(testAddrA, testAddrB, testContract, big.NewInt(1), 100)
+			require.ErrorContains(t, err, "node returned no transaction")
+			require.Nil(t, tx)
+		})
+	})
+
+	t.Run("TriggerContract/non-zero result code", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			TriggerContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+				return rejectedTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			tx, err := c.TriggerContract(testAddrA, testContract, "transfer(address,uint256)",
+				`[{"address": "`+testAddrB+`"},{"uint256": "1"}]`, 100, 0, "", 0)
+			require.ErrorContains(t, err, "node refused the request")
+			require.Nil(t, tx)
+		})
+	})
+
+	t.Run("TriggerContract/success no transaction", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			TriggerContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			tx, err := c.TriggerContract(testAddrA, testContract, "transfer(address,uint256)",
+				`[{"address": "`+testAddrB+`"},{"uint256": "1"}]`, 100, 0, "", 0)
+			require.ErrorContains(t, err, "node returned no transaction")
+			require.Nil(t, tx)
 		})
 	})
 }

--- a/pkg/client/untrusted_input_test.go
+++ b/pkg/client/untrusted_input_test.go
@@ -125,9 +125,25 @@ func TestUpdateAccountPermission_MalformedMaps(t *testing.T) {
 				"name": "active", "threshold": int64(1), "keys": map[string]int64{testAddrA: 1},
 			}},
 		},
+		"active threshold wrong type": {
+			owner: validOwner,
+			actives: []map[string]interface{}{{
+				"name": "active", "threshold": 1, "operations": map[string]bool{}, "keys": map[string]int64{testAddrA: 1},
+			}},
+		},
+		"active keys wrong type": {
+			owner: validOwner,
+			actives: []map[string]interface{}{{
+				"name": "active", "threshold": int64(1), "operations": map[string]bool{}, "keys": "nope",
+			}},
+		},
 		"witness missing keys": {
 			owner:   validOwner,
 			witness: map[string]interface{}{"threshold": int64(1)},
+		},
+		"witness threshold wrong type": {
+			owner:   validOwner,
+			witness: map[string]interface{}{"threshold": 1, "keys": map[string]int64{testAddrA: 1}},
 		},
 	}
 
@@ -383,6 +399,240 @@ func TestEstimateEnergy_NilResponse(t *testing.T) {
 		_, err := c.EstimateEnergy(testAddrA, testContract, "transfer(address,uint256)",
 			`[{"address": "`+testAddrB+`"},{"uint256": "1"}]`, 0, "", 0)
 		require.ErrorContains(t, err, "empty response")
+	})
+}
+
+func TestEstimateEnergy_NodeRejection(t *testing.T) {
+	params := `[{"address": "` + testAddrB + `"},{"uint256": "1"}]`
+
+	t.Run("non-zero code with message", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			EstimateEnergyFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.EstimateEnergyMessage, error) {
+				return &api.EstimateEnergyMessage{
+					Result: &api.Return{
+						Result:  false,
+						Code:    api.Return_CONTRACT_VALIDATE_ERROR,
+						Message: []byte("out of energy estimate"),
+					},
+				}, nil
+			},
+		})
+		_, err := c.EstimateEnergy(testAddrA, testContract, "transfer(address,uint256)", params, 0, "", 0)
+		require.ErrorContains(t, err, "out of energy estimate")
+	})
+
+	t.Run("non-zero code empty message", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			EstimateEnergyFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.EstimateEnergyMessage, error) {
+				return &api.EstimateEnergyMessage{
+					Result: &api.Return{
+						Result: false,
+						Code:   api.Return_CONTRACT_VALIDATE_ERROR,
+					},
+				}, nil
+			},
+		})
+		_, err := c.EstimateEnergy(testAddrA, testContract, "transfer(address,uint256)", params, 0, "", 0)
+		require.ErrorContains(t, err, "node rejected request")
+	})
+}
+
+// More write builders must surface SUCCESS-without-transaction through requireTxExtension.
+func TestBuilders_SuccessNoTransaction(t *testing.T) {
+	t.Run("Transfer", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			CreateTransaction2Func: func(_ context.Context, _ *core.TransferContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.Transfer(testAddrA, testAddrB, 1)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("UpdateAccount", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			UpdateAccount2Func: func(_ context.Context, _ *core.AccountUpdateContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.UpdateAccount(testAddrA, "name")
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("FreezeBalanceV2", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			FreezeBalanceV2Func: func(_ context.Context, _ *core.FreezeBalanceV2Contract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.FreezeBalanceV2(testAddrA, core.ResourceCode_BANDWIDTH, 1_000_000)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("UpdateEnergyLimitContract", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			UpdateEnergyLimitFunc: func(_ context.Context, _ *core.UpdateEnergyLimitContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.UpdateEnergyLimitContract(testAddrA, testContract, 1_000_000)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("UpdateSettingContract", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			UpdateSettingFunc: func(_ context.Context, _ *core.UpdateSettingContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.UpdateSettingContract(testAddrA, testContract, 50)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("CreateWitness", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			CreateWitness2Func: func(_ context.Context, _ *core.WitnessCreateContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.CreateWitness(testAddrA, "https://example.com")
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("ProposalCreate", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			ProposalCreateFunc: func(_ context.Context, _ *core.ProposalCreateContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.ProposalCreate(testAddrA, map[int64]int64{1: 2})
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("ExchangeCreate", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			ExchangeCreateFunc: func(_ context.Context, _ *core.ExchangeCreateContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.ExchangeCreate(testAddrA, "_", 1_000_000, "_", 1_000_000)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("UnfreezeBalance", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			UnfreezeBalance2Func: func(_ context.Context, _ *core.UnfreezeBalanceContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.UnfreezeBalance(testAddrA, "", core.ResourceCode_BANDWIDTH)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("UnfreezeBalanceV2", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			UnfreezeBalanceV2Func: func(_ context.Context, _ *core.UnfreezeBalanceV2Contract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.UnfreezeBalanceV2(testAddrA, core.ResourceCode_BANDWIDTH, 1_000_000)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("ProposalApprove", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			ProposalApproveFunc: func(_ context.Context, _ *core.ProposalApproveContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.ProposalApprove(testAddrA, 1, true)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("UpdateWitness", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			UpdateWitness2Func: func(_ context.Context, _ *core.WitnessUpdateContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.UpdateWitness(testAddrA, "https://example.com")
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("UpdateAccountPermission", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			AccountPermissionUpdateFunc: func(_ context.Context, _ *core.AccountPermissionUpdateContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		owner := map[string]interface{}{
+			"threshold": int64(1),
+			"keys":      map[string]int64{testAddrA: 1},
+		}
+		require.NotPanics(t, func() {
+			_, err := c.UpdateAccountPermission(testAddrA, owner, nil, nil)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("ExchangeInject", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			ExchangeInjectFunc: func(_ context.Context, _ *core.ExchangeInjectContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.ExchangeInject(testAddrA, 1, "_", 1_000_000)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("ExchangeWithdraw", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			ExchangeWithdrawFunc: func(_ context.Context, _ *core.ExchangeWithdrawContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.ExchangeWithdraw(testAddrA, 1, "_", 1_000_000)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
+	})
+
+	t.Run("ExchangeTrade", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			ExchangeTransactionFunc: func(_ context.Context, _ *core.ExchangeTransactionContract) (*api.TransactionExtention, error) {
+				return successNoTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.ExchangeTrade(testAddrA, 1, "_", 100, 1)
+			require.ErrorContains(t, err, "node returned no transaction")
+		})
 	})
 }
 

--- a/pkg/client/untrusted_input_test.go
+++ b/pkg/client/untrusted_input_test.go
@@ -1,0 +1,333 @@
+package client_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
+	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+const (
+	testAddrA    = "TPpw7soPWEDQWXPCGUMagYPryaWrYR5b3b"
+	testAddrB    = "TLyqzVGLV1srkB7dToTAEqgDSfPtXRJZYH"
+	testContract = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t"
+)
+
+// emptyConstantResultMock reports success but returns no constant_result entries,
+// which is what a hostile or buggy node can legitimately send back.
+func emptyConstantResultMock() *mockWalletServer {
+	return &mockWalletServer{
+		TriggerConstantContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			return &api.TransactionExtention{
+				Result:         &api.Return{Result: true, Code: api.Return_SUCCESS},
+				ConstantResult: nil,
+			}, nil
+		},
+	}
+}
+
+// A success code with an empty constant_result previously reached
+// GetConstantResult()[0] and panicked with index out of range.
+func TestTRC20Queries_EmptyConstantResult(t *testing.T) {
+	c := newMockClient(t, emptyConstantResultMock())
+
+	calls := map[string]func() error{
+		"TRC20GetName":     func() error { _, err := c.TRC20GetName(testContract); return err },
+		"TRC20GetSymbol":   func() error { _, err := c.TRC20GetSymbol(testContract); return err },
+		"TRC20GetDecimals": func() error { _, err := c.TRC20GetDecimals(testContract); return err },
+		"TRC20ContractBalance": func() error {
+			_, err := c.TRC20ContractBalance(testAddrA, testContract)
+			return err
+		},
+	}
+
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				require.Error(t, call())
+			})
+		})
+	}
+}
+
+// big.Int.Bytes returns the absolute value, so a negative amount was silently
+// encoded as a real positive transfer. A nil amount panicked, and a value wider
+// than 256 bits was appended whole because LeftPadBytes does not truncate.
+func TestTRC20Writes_RejectInvalidAmount(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+
+	amounts := map[string]*big.Int{
+		"nil":                 nil,
+		"negative":            big.NewInt(-1),
+		"wider than 256 bits": new(big.Int).Lsh(big.NewInt(1), 256),
+	}
+
+	for name, amount := range amounts {
+		t.Run(name, func(t *testing.T) {
+			t.Run("TRC20Send", func(t *testing.T) {
+				require.NotPanics(t, func() {
+					_, err := c.TRC20Send(testAddrA, testAddrB, testContract, amount, 100)
+					require.Error(t, err)
+				})
+			})
+			t.Run("TRC20Approve", func(t *testing.T) {
+				require.NotPanics(t, func() {
+					_, err := c.TRC20Approve(testAddrA, testAddrB, testContract, amount, 100)
+					require.Error(t, err)
+				})
+			})
+			t.Run("TRC20TransferFrom", func(t *testing.T) {
+				require.NotPanics(t, func() {
+					_, err := c.TRC20TransferFrom(testAddrA, testAddrB, testAddrB, testContract, amount, 100)
+					require.Error(t, err)
+				})
+			})
+		})
+	}
+}
+
+// The permission API takes map[string]interface{}, so a missing key or a plain
+// int where int64 was meant previously panicked part-way through a multisig
+// permission update rather than returning an error.
+func TestUpdateAccountPermission_MalformedMaps(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+
+	validOwner := map[string]interface{}{
+		"threshold": int64(1),
+		"keys":      map[string]int64{testAddrA: 1},
+	}
+
+	tests := map[string]struct {
+		owner   map[string]interface{}
+		witness map[string]interface{}
+		actives []map[string]interface{}
+	}{
+		"owner missing threshold": {
+			owner: map[string]interface{}{"keys": map[string]int64{testAddrA: 1}},
+		},
+		"owner missing keys": {
+			owner: map[string]interface{}{"threshold": int64(1)},
+		},
+		"owner threshold is int not int64": {
+			owner: map[string]interface{}{"threshold": 1, "keys": map[string]int64{testAddrA: 1}},
+		},
+		"active missing name": {
+			owner:   validOwner,
+			actives: []map[string]interface{}{{"threshold": int64(1)}},
+		},
+		"active missing operations": {
+			owner: validOwner,
+			actives: []map[string]interface{}{{
+				"name": "active", "threshold": int64(1), "keys": map[string]int64{testAddrA: 1},
+			}},
+		},
+		"witness missing keys": {
+			owner:   validOwner,
+			witness: map[string]interface{}{"threshold": int64(1)},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := c.UpdateAccountPermission(testAddrA, tt.owner, tt.witness, tt.actives)
+				require.Error(t, err)
+			})
+		})
+	}
+}
+
+// rejectedTx is what a node sends when it refuses a request: a nil gRPC error, a
+// non-zero result code, a reason, and no Transaction.
+func rejectedTx() *api.TransactionExtention {
+	return &api.TransactionExtention{
+		Result: &api.Return{
+			Result:  false,
+			Code:    api.Return_CONTRACT_VALIDATE_ERROR,
+			Message: []byte("node refused the request"),
+		},
+	}
+}
+
+// These builders previously returned the rejection as an apparently valid
+// TransactionExtention, so the failure surfaced only after signing and
+// broadcast — or not at all.
+func TestBuilders_SurfaceNodeRejection(t *testing.T) {
+	t.Run("WithdrawExpireUnfreeze", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			WithdrawExpireUnfreezeFunc: func(_ context.Context, _ *core.WithdrawExpireUnfreezeContract) (*api.TransactionExtention, error) {
+				return rejectedTx(), nil
+			},
+		})
+		_, err := c.WithdrawExpireUnfreeze(testAddrA, 1700000000000)
+		require.ErrorContains(t, err, "node refused the request")
+	})
+
+	t.Run("DelegateResource", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			DelegateResourceFunc: func(_ context.Context, _ *core.DelegateResourceContract) (*api.TransactionExtention, error) {
+				return rejectedTx(), nil
+			},
+		})
+		_, err := c.DelegateResource(testAddrA, testAddrB, core.ResourceCode_BANDWIDTH, 1_000_000, false, 0)
+		require.ErrorContains(t, err, "node refused the request")
+	})
+
+	t.Run("UnDelegateResource", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			UnDelegateResourceFunc: func(_ context.Context, _ *core.UnDelegateResourceContract) (*api.TransactionExtention, error) {
+				return rejectedTx(), nil
+			},
+		})
+		_, err := c.UnDelegateResource(testAddrA, testAddrB, core.ResourceCode_BANDWIDTH, 1_000_000)
+		require.ErrorContains(t, err, "node refused the request")
+	})
+}
+
+// DeployContractCtx assigned to tx.Transaction.RawData without checking the
+// result, so a rejection nil-dereferenced instead of reporting the reason.
+func TestDeployContract_NodeRejection(t *testing.T) {
+	t.Run("non-zero result code", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			DeployContractFunc: func(_ context.Context, _ *core.CreateSmartContract) (*api.TransactionExtention, error) {
+				return rejectedTx(), nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.DeployContract(testAddrA, "Test", &core.SmartContract_ABI{}, "6080", 100, 50, 10000)
+			require.ErrorContains(t, err, "node refused the request")
+		})
+	})
+
+	t.Run("success code but no transaction", func(t *testing.T) {
+		c := newMockClient(t, &mockWalletServer{
+			DeployContractFunc: func(_ context.Context, _ *core.CreateSmartContract) (*api.TransactionExtention, error) {
+				return &api.TransactionExtention{
+					Result: &api.Return{Result: true, Code: api.Return_SUCCESS},
+				}, nil
+			},
+		})
+		require.NotPanics(t, func() {
+			_, err := c.DeployContract(testAddrA, "Test", &core.SmartContract_ABI{}, "6080", 100, 50, 10000)
+			require.Error(t, err)
+		})
+	})
+}
+
+// nilInfoWalletClient returns a literal nil TransactionInfo with a nil error.
+//
+// This cannot be produced through the mock gRPC server: grpc-go materialises a
+// (nil, nil) server return into an empty message on the wire, so the client
+// always receives a non-nil value. Stubbing the exported Client field is the only
+// way to reach the guard — and it is the case that matters, because an SDK
+// consumer may substitute its own api.WalletClient. The embedded interface is nil,
+// which is fine: only the overridden method is called.
+type nilInfoWalletClient struct{ api.WalletClient }
+
+// The Id spelling is fixed by the generated api.WalletClient interface.
+//
+//nolint:staticcheck // ST1003: must match the generated method name to satisfy the interface
+func (nilInfoWalletClient) GetTransactionInfoById(
+	context.Context, *api.BytesMessage, ...grpc.CallOption,
+) (*core.TransactionInfo, error) {
+	return nil, nil
+}
+
+// A nil response alongside a nil error previously reached txi.Id and panicked.
+func TestGetTransactionInfoByID_NilResponse(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+	c.Client = nilInfoWalletClient{}
+
+	require.NotPanics(t, func() {
+		_, err := c.GetTransactionInfoByID("abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+		require.ErrorContains(t, err, "empty response")
+	})
+}
+
+// An empty (non-nil) response is the shape a real gRPC round trip produces.
+func TestGetTransactionInfoByID_EmptyResponse(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{
+		GetTransactionInfoByIdFunc: func(_ context.Context, _ *api.BytesMessage) (*core.TransactionInfo, error) {
+			return nil, nil
+		},
+	})
+	require.NotPanics(t, func() {
+		_, err := c.GetTransactionInfoByID("abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890")
+		require.Error(t, err)
+	})
+}
+
+// nilResultWalletClient returns a TransactionExtention whose Result is nil,
+// which the raw tx.Result.Code dereferences panicked on. As with the nil
+// TransactionInfo above, a real gRPC round trip always materialises Result, so
+// stubbing the exported Client field is the only way to reach these branches —
+// and an SDK consumer substituting its own api.WalletClient can produce exactly
+// this shape.
+type nilResultWalletClient struct{ api.WalletClient }
+
+func (nilResultWalletClient) TriggerConstantContract(
+	context.Context, *core.TriggerSmartContract, ...grpc.CallOption,
+) (*api.TransactionExtention, error) {
+	return &api.TransactionExtention{ConstantResult: [][]byte{make([]byte, 32)}}, nil
+}
+
+func (nilResultWalletClient) TriggerContract(
+	context.Context, *core.TriggerSmartContract, ...grpc.CallOption,
+) (*api.TransactionExtention, error) {
+	return &api.TransactionExtention{}, nil
+}
+
+func (nilResultWalletClient) DeployContract(
+	context.Context, *core.CreateSmartContract, ...grpc.CallOption,
+) (*api.TransactionExtention, error) {
+	return &api.TransactionExtention{}, nil
+}
+
+func TestNilResultIsNotDereferenced(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+	c.Client = nilResultWalletClient{}
+
+	t.Run("TRC20GetDecimals via TRC20CallCtx", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			// Result is nil but a well-formed constant result is present, so this
+			// must survive the nil Result and decode normally.
+			_, err := c.TRC20GetDecimals(testContract)
+			require.NoError(t, err)
+		})
+	})
+
+	t.Run("triggerContract", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, err := c.TRC20Send(testAddrA, testAddrB, testContract, big.NewInt(1), 100)
+			require.Error(t, err)
+		})
+	})
+
+	t.Run("DeployContract", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			_, err := c.DeployContract(testAddrA, "Test", &core.SmartContract_ABI{}, "6080", 100, 50, 10000)
+			require.Error(t, err)
+		})
+	})
+}
+
+// Constant results are 32-byte aligned, so a shorter entry is malformed.
+func TestTRC20Queries_ShortConstantResult(t *testing.T) {
+	short := &mockWalletServer{
+		TriggerConstantContractFunc: func(_ context.Context, _ *core.TriggerSmartContract) (*api.TransactionExtention, error) {
+			return &api.TransactionExtention{
+				Result:         &api.Return{Result: true, Code: api.Return_SUCCESS},
+				ConstantResult: [][]byte{{0x01, 0x02}},
+			}, nil
+		},
+	}
+	c := newMockClient(t, short)
+	require.NotPanics(t, func() {
+		_, err := c.TRC20GetDecimals(testContract)
+		require.ErrorContains(t, err, "expected at least 32")
+	})
+}

--- a/pkg/client/untrusted_input_test.go
+++ b/pkg/client/untrusted_input_test.go
@@ -346,6 +346,46 @@ func TestGetTransactionInfoByID_NilResponse(t *testing.T) {
 	})
 }
 
+// nilAccountWalletClient returns a literal nil Account with a nil error.
+type nilAccountWalletClient struct{ api.WalletClient }
+
+func (nilAccountWalletClient) GetAccount(
+	context.Context, *core.Account, ...grpc.CallOption,
+) (*core.Account, error) {
+	return nil, nil
+}
+
+// A nil Account previously reached acc.Address and panicked.
+func TestGetAccount_NilResponse(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+	c.Client = nilAccountWalletClient{}
+
+	require.NotPanics(t, func() {
+		_, err := c.GetAccount(testAddrA)
+		require.ErrorContains(t, err, "account not found")
+	})
+}
+
+// nilEstimateWalletClient returns a literal nil EstimateEnergyMessage.
+type nilEstimateWalletClient struct{ api.WalletClient }
+
+func (nilEstimateWalletClient) EstimateEnergy(
+	context.Context, *core.TriggerSmartContract, ...grpc.CallOption,
+) (*api.EstimateEnergyMessage, error) {
+	return nil, nil
+}
+
+func TestEstimateEnergy_NilResponse(t *testing.T) {
+	c := newMockClient(t, &mockWalletServer{})
+	c.Client = nilEstimateWalletClient{}
+
+	require.NotPanics(t, func() {
+		_, err := c.EstimateEnergy(testAddrA, testContract, "transfer(address,uint256)",
+			`[{"address": "`+testAddrB+`"},{"uint256": "1"}]`, 0, "", 0)
+		require.ErrorContains(t, err, "empty response")
+	})
+}
+
 // An empty (non-nil) response is the shape a real gRPC round trip produces.
 func TestGetTransactionInfoByID_EmptyResponse(t *testing.T) {
 	c := newMockClient(t, &mockWalletServer{

--- a/pkg/client/witnesses.go
+++ b/pkg/client/witnesses.go
@@ -2,12 +2,10 @@ package client
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/common"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/api"
 	"github.com/fbsobreira/gotron-sdk/pkg/proto/core"
-	"google.golang.org/protobuf/proto"
 )
 
 // ListWitnesses return all witnesses
@@ -65,11 +63,8 @@ func (g *GrpcClient) CreateWitnessCtx(ctx context.Context, from, urlStr string) 
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "create witness"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -97,11 +92,8 @@ func (g *GrpcClient) UpdateWitnessCtx(ctx context.Context, from, urlStr string) 
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "update witness"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -143,11 +135,8 @@ func (g *GrpcClient) VoteWitnessAccountCtx(ctx context.Context, from string,
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "vote witness account"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }
@@ -199,11 +188,8 @@ func (g *GrpcClient) UpdateBrokerageCtx(ctx context.Context, from string, commis
 	if err != nil {
 		return nil, err
 	}
-	if proto.Size(tx) == 0 {
-		return nil, fmt.Errorf("bad transaction")
-	}
-	if tx.GetResult().GetCode() != 0 {
-		return nil, fmt.Errorf("%s", tx.GetResult().GetMessage())
+	if err := requireTxExtension(tx, "update brokerage"); err != nil {
+		return nil, err
 	}
 	return tx, nil
 }

--- a/pkg/common/numeric/numeric.go
+++ b/pkg/common/numeric/numeric.go
@@ -639,6 +639,22 @@ var (
 	pattern = regexp.MustCompile(`^[0-9]+\.{0,1}[0-9]*e-{0,1}[0-9]+$`)
 )
 
+// maxDecExponent bounds the scientific-notation exponent accepted by
+// NewDecFromString. The regex allows any number of digits and Atoi accepts the
+// whole int range, so without this a short string reaches Pow with an arbitrary
+// exponent, where two things go wrong:
+//
+//   - Dec is capped at 255+DecimalPrecisionBits bits over an 18-decimal scale, so
+//     Pow(10, e) panics with "Int overflow" once e exceeds 76 (verified: 10^76 is
+//     representable, 10^77 panics).
+//   - Pow negates a negative exponent, and for math.MinInt the negation stays
+//     negative, so it recurses until the stack overflows.
+//
+// The bound is symmetric: an exponent below -76 cannot be represented either, and
+// silently collapsing such an input to zero is the same class of wrong-value bug
+// this parser is being hardened against.
+const maxDecExponent = 76
+
 // Pow calcs power of numeric with int
 func Pow(base Dec, exp int) Dec {
 	if exp < 0 {
@@ -672,6 +688,9 @@ func NewDecFromString(i string) (Dec, error) {
 		b, err := strconv.Atoi(tokens[1])
 		if err != nil {
 			return ZeroDec(), fmt.Errorf("invalid exponent %q in %q: %w", tokens[1], i, err)
+		}
+		if b > maxDecExponent || b < -maxDecExponent {
+			return ZeroDec(), fmt.Errorf("exponent %d in %q outside [-%d, %d]", b, i, maxDecExponent, maxDecExponent)
 		}
 		return a.Mul(Pow(NewDec(10), b)), nil
 	}

--- a/pkg/common/numeric/numeric.go
+++ b/pkg/common/numeric/numeric.go
@@ -179,6 +179,11 @@ func NewDecFromStr(str string) (d Dec, err error) {
 	if !ok {
 		return d, fmt.Errorf("bad string to integer conversion, combinedStr: %v", combinedStr)
 	}
+	// Same bit cap as Mul/Add/etc. Without this, a large plain decimal builds a
+	// Dec that later arithmetic panics on ("Int overflow").
+	if combined.BitLen() > 255+DecimalPrecisionBits {
+		return ZeroDec(), ErrOutOfRange
+	}
 	if neg {
 		combined = new(big.Int).Neg(combined)
 	}
@@ -724,7 +729,14 @@ func NewDecFromString(i string) (dec Dec, err error) {
 		if b > maxDecExponent || b < -maxDecExponent {
 			return ZeroDec(), fmt.Errorf("exponent %d in %q outside [-%d, %d]", b, i, maxDecExponent, maxDecExponent)
 		}
-		return a.Mul(Pow(NewDec(10), b)), nil
+		result := a.Mul(Pow(NewDec(10), b))
+		// Negative exponents can collapse a nonzero mantissa to zero at 18-digit
+		// fixed-point precision (e.g. 1e-19). That is a silent wrong value, not a
+		// valid zero — reject it the same way overflow is rejected.
+		if !a.IsZero() && result.IsZero() {
+			return ZeroDec(), fmt.Errorf("value underflows fixed-point precision: %q", i)
+		}
+		return result, nil
 	}
 	if strings.HasPrefix(i, ".") {
 		i = "0" + i

--- a/pkg/common/numeric/numeric.go
+++ b/pkg/common/numeric/numeric.go
@@ -634,7 +634,9 @@ func MaxDec(d1, d2 Dec) Dec {
 }
 
 var (
-	pattern, _ = regexp.Compile(`[0-9]+\.{0,1}[0-9]*e-{0,1}[0-9]+`)
+	// Anchored: an unanchored pattern also matches inside malformed input such as
+	// "1e5x", which then parsed as 1 with a nil error.
+	pattern = regexp.MustCompile(`^[0-9]+\.{0,1}[0-9]*e-{0,1}[0-9]+$`)
 )
 
 // Pow calcs power of numeric with int
@@ -661,10 +663,16 @@ func NewDecFromString(i string) (Dec, error) {
 	if strings.HasPrefix(i, "-") {
 		return ZeroDec(), fmt.Errorf("can not be negative: %s", i)
 	}
-	if pattern.FindString(i) != "" {
+	if pattern.MatchString(i) {
 		tokens := strings.Split(i, "e")
-		a, _ := NewDecFromStr(tokens[0])
-		b, _ := strconv.Atoi(tokens[1])
+		a, err := NewDecFromStr(tokens[0])
+		if err != nil {
+			return ZeroDec(), fmt.Errorf("invalid mantissa %q in %q: %w", tokens[0], i, err)
+		}
+		b, err := strconv.Atoi(tokens[1])
+		if err != nil {
+			return ZeroDec(), fmt.Errorf("invalid exponent %q in %q: %w", tokens[1], i, err)
+		}
 		return a.Mul(Pow(NewDec(10), b)), nil
 	}
 	if strings.HasPrefix(i, ".") {
@@ -676,16 +684,36 @@ func NewDecFromString(i string) (Dec, error) {
 
 // NewDecFromHex Assumes Hex string input
 // Split into 2 64 bit integers to guarantee 128 bit precision
+//
+// Invalid hex — the empty string, non-hex digits, or a sign — returns ZeroDec.
+// It previously let a nil *big.Int from SetString reach big.Int.Mul, which
+// panicked, so no caller that works today changes behaviour. The signature
+// cannot report the condition; gaining an error return is queued as a breaking
+// change.
 func NewDecFromHex(str string) Dec {
 	str = strings.TrimPrefix(str, "0x")
+	if str == "" {
+		return ZeroDec()
+	}
+	// big.Int.SetString accepts a leading sign, so "-abc" would split into a
+	// negative left half and yield a negative Dec from a hex parser.
+	if strings.ContainsAny(str, "+-") {
+		return ZeroDec()
+	}
 	half := len(str) / 2
 	right := str[half:]
-	r, _ := big.NewInt(0).SetString(right, 16)
+	r, ok := big.NewInt(0).SetString(right, 16)
+	if !ok {
+		return ZeroDec()
+	}
 	if half == 0 {
 		return NewDecFromBigInt(r)
 	}
 	left := str[:half]
-	l, _ := big.NewInt(0).SetString(left, 16)
+	l, ok := big.NewInt(0).SetString(left, 16)
+	if !ok {
+		return ZeroDec()
+	}
 	return NewDecFromBigInt(l).Mul(
 		Pow(NewDec(16), len(right)),
 	).Add(NewDecFromBigInt(r))

--- a/pkg/common/numeric/numeric.go
+++ b/pkg/common/numeric/numeric.go
@@ -653,7 +653,38 @@ var (
 // The bound is symmetric: an exponent below -76 cannot be represented either, and
 // silently collapsing such an input to zero is the same class of wrong-value bug
 // this parser is being hardened against.
+//
+// The bound is necessary but not sufficient — see recoverIntOverflow.
 const maxDecExponent = 76
+
+// ErrOutOfRange reports a value outside the range Dec can represent.
+var ErrOutOfRange = errors.New("value out of representable range")
+
+// recoverIntOverflow converts the "Int overflow" panic raised by Dec's
+// fixed-point operations into ErrOutOfRange, and re-raises anything else so real
+// bugs still surface.
+//
+// Dec's arithmetic panics instead of returning an error, and deciding in advance
+// whether a parsed value fits is unreliable: the exponent bound is necessary but
+// not sufficient, because the magnitude depends on the mantissa too — 1e76 is
+// representable while 9e76 is not — and on the hex path a 64-character string,
+// which is just an ABI uint256 word, overflows as well. Catching the documented
+// panic covers every arithmetic path exactly, where hand-derived bit arithmetic
+// would only approximate it.
+// It must be deferred directly — recover() only returns the panic value when
+// called by the deferred function itself, not by something that function calls.
+func recoverIntOverflow(dec *Dec, err *error) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	if s, ok := r.(string); ok && s == "Int overflow" {
+		*dec = ZeroDec()
+		*err = ErrOutOfRange
+		return
+	}
+	panic(r)
+}
 
 // Pow calcs power of numeric with int
 func Pow(base Dec, exp int) Dec {
@@ -675,7 +706,8 @@ func Pow(base Dec, exp int) Dec {
 }
 
 // NewDecFromString from string to DEC
-func NewDecFromString(i string) (Dec, error) {
+func NewDecFromString(i string) (dec Dec, err error) {
+	defer recoverIntOverflow(&dec, &err)
 	if strings.HasPrefix(i, "-") {
 		return ZeroDec(), fmt.Errorf("can not be negative: %s", i)
 	}
@@ -709,7 +741,12 @@ func NewDecFromString(i string) (Dec, error) {
 // panicked, so no caller that works today changes behaviour. The signature
 // cannot report the condition; gaining an error return is queued as a breaking
 // change.
-func NewDecFromHex(str string) Dec {
+func NewDecFromHex(str string) (dec Dec) {
+	// A 64-character string — an ordinary ABI uint256 word — exceeds Dec's range,
+	// and the signature cannot report it, so it degrades to zero like other
+	// invalid input.
+	var err error
+	defer recoverIntOverflow(&dec, &err)
 	str = strings.TrimPrefix(str, "0x")
 	if str == "" {
 		return ZeroDec()

--- a/pkg/common/numeric/parse_malformed_test.go
+++ b/pkg/common/numeric/parse_malformed_test.go
@@ -40,6 +40,12 @@ func TestNewDecFromString_Malformed(t *testing.T) {
 		// mantissa too, so these are inside [-76, 76] and still overflow.
 		"9e76",
 		"99e75",
+		// Plain (non-scientific) path must enforce the same bit cap; previously
+		// a huge integer string built a Dec that later Mul/Add panicked on.
+		"9" + strings.Repeat("0", 80),
+		// Fixed-point underflow: nonzero mantissa collapses to zero at 18 digits.
+		"1e-19",
+		"5e-20",
 	} {
 		t.Run(in, func(t *testing.T) {
 			require.NotPanics(t, func() {
@@ -48,6 +54,19 @@ func TestNewDecFromString_Malformed(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestNewDecFromString_UnderflowAndOverflowErrors(t *testing.T) {
+	_, err := numeric.NewDecFromString("1e-19")
+	require.ErrorContains(t, err, "underflows")
+
+	_, err = numeric.NewDecFromString("9" + strings.Repeat("0", 80))
+	require.ErrorIs(t, err, numeric.ErrOutOfRange)
+
+	// Smallest positive unit at 18-digit precision is still representable.
+	d, err := numeric.NewDecFromString("1e-18")
+	require.NoError(t, err)
+	require.False(t, d.IsZero())
 }
 
 func TestNewDecFromString_Valid(t *testing.T) {

--- a/pkg/common/numeric/parse_malformed_test.go
+++ b/pkg/common/numeric/parse_malformed_test.go
@@ -36,6 +36,10 @@ func TestNewDecFromString_Malformed(t *testing.T) {
 		// 10^77 exceeds Dec's bit cap and panicked with "Int overflow".
 		"1e77",
 		"1e-77",
+		// The exponent bound alone is not enough: magnitude depends on the
+		// mantissa too, so these are inside [-76, 76] and still overflow.
+		"9e76",
+		"99e75",
 	} {
 		t.Run(in, func(t *testing.T) {
 			require.NotPanics(t, func() {
@@ -89,6 +93,11 @@ func TestNewDecFromHex_Malformed(t *testing.T) {
 		"-abcd",
 		"+abcd",
 		"0x-abcd",
+		// 64 hex chars is an ordinary ABI uint256 word and exceeds Dec's range;
+		// this panicked with "Int overflow".
+		strings.Repeat("f", 64),
+		strings.Repeat("f", 200),
+		"0x" + strings.Repeat("a", 64),
 	} {
 		t.Run(in, func(t *testing.T) {
 			require.NotPanics(t, func() {

--- a/pkg/common/numeric/parse_malformed_test.go
+++ b/pkg/common/numeric/parse_malformed_test.go
@@ -1,6 +1,7 @@
 package numeric_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/fbsobreira/gotron-sdk/pkg/common/numeric"
@@ -25,6 +26,16 @@ func TestNewDecFromString_Malformed(t *testing.T) {
 		"1e5 ",
 		"--1",
 		"1.2.3",
+		// Pow negates a negative exponent; math.MinInt stays negative when
+		// negated, so this recursed until the stack overflowed. Large positive
+		// exponents build an astronomically large big.Int instead.
+		"1e-9223372036854775808",
+		"1e9223372036854775807",
+		"1e100000",
+		"1e-100000",
+		// 10^77 exceeds Dec's bit cap and panicked with "Int overflow".
+		"1e77",
+		"1e-77",
 	} {
 		t.Run(in, func(t *testing.T) {
 			require.NotPanics(t, func() {
@@ -41,6 +52,7 @@ func TestNewDecFromString_Valid(t *testing.T) {
 		want string
 	}{
 		{"1e5", "100000.000000000000000000"},
+		{"1e76", "1" + strings.Repeat("0", 76) + ".000000000000000000"},
 		{"2.5e3", "2500.000000000000000000"},
 		{".5", "0.500000000000000000"},
 		{"1", "1.000000000000000000"},

--- a/pkg/common/numeric/parse_malformed_test.go
+++ b/pkg/common/numeric/parse_malformed_test.go
@@ -1,0 +1,95 @@
+package numeric_test
+
+import (
+	"testing"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/common/numeric"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The scientific-notation regex was unanchored, so malformed input like "1e5x"
+// matched, strconv.Atoi("5x") failed silently leaving the exponent at 0, and the
+// function returned 1 with a nil error — a silently wrong monetary value.
+func TestNewDecFromString_Malformed(t *testing.T) {
+	for _, in := range []string{
+		"1e5x",
+		"1e5.5",
+		"x1e5",
+		"1e5e5",
+		"1e",
+		"e5",
+		"abc",
+		"",
+		" 1e5",
+		"1e5 ",
+		"--1",
+		"1.2.3",
+	} {
+		t.Run(in, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				_, err := numeric.NewDecFromString(in)
+				require.Error(t, err, "malformed input %q must not parse", in)
+			})
+		})
+	}
+}
+
+func TestNewDecFromString_Valid(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"1e5", "100000.000000000000000000"},
+		{"2.5e3", "2500.000000000000000000"},
+		{".5", "0.500000000000000000"},
+		{"1", "1.000000000000000000"},
+		{"0", "0.000000000000000000"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := numeric.NewDecFromString(tt.in)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got.String())
+		})
+	}
+}
+
+func TestNewDecFromString_Negative(t *testing.T) {
+	_, err := numeric.NewDecFromString("-1")
+	require.Error(t, err)
+}
+
+// Invalid hex left a nil *big.Int from SetString flowing into big.Int.Mul, which
+// panicked. The signature cannot report the condition, so these return ZeroDec.
+func TestNewDecFromHex_Malformed(t *testing.T) {
+	for _, in := range []string{
+		"",
+		"0x",
+		"zz",
+		"0xzz",
+		"12g4",
+		"0x 1",
+		"-1",
+		// big.Int.SetString accepts a sign, so these previously produced a
+		// negative Dec out of a hex parser.
+		"-abc",
+		"-abcd",
+		"+abcd",
+		"0x-abcd",
+	} {
+		t.Run(in, func(t *testing.T) {
+			require.NotPanics(t, func() {
+				got := numeric.NewDecFromHex(in)
+				assert.True(t, got.IsZero(), "malformed hex %q should give zero, got %s", in, got)
+			})
+		})
+	}
+}
+
+func TestNewDecFromHex_Valid(t *testing.T) {
+	require.NotPanics(t, func() {
+		assert.False(t, numeric.NewDecFromHex("0xff").IsZero())
+		assert.False(t, numeric.NewDecFromHex("ff").IsZero())
+	})
+}

--- a/pkg/keystore/cipherparams_test.go
+++ b/pkg/keystore/cipherparams_test.go
@@ -91,6 +91,35 @@ func TestDecryptKey_MalformedCipherFields(t *testing.T) {
 	}
 }
 
+func TestDecryptKey_InvalidHexCipherFields(t *testing.T) {
+	tests := map[string]func() map[string]interface{}{
+		"mac not hex": func() map[string]interface{} {
+			c := validCrypto()
+			c["mac"] = "zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"
+			return c
+		},
+		"iv not hex": func() map[string]interface{} {
+			c := validCrypto()
+			c["cipherparams"] = map[string]interface{}{"iv": "gggggggggggggggggggggggggggggggg"}
+			return c
+		},
+		"ciphertext not hex": func() map[string]interface{} {
+			c := validCrypto()
+			c["ciphertext"] = "not-valid-hex!!!"
+			return c
+		},
+	}
+	for name, build := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := keystoreWithCrypto(t, build())
+			require.NotPanics(t, func() {
+				_, err := keystore.DecryptKey(doc, "passphrase")
+				require.Error(t, err)
+			})
+		})
+	}
+}
+
 // V1 CBC decrypt previously panicked in CryptBlocks when ciphertext was not a
 // multiple of the AES block size, even after a successful MAC check.
 func TestDecryptKey_V1CiphertextNotBlockAligned(t *testing.T) {

--- a/pkg/keystore/cipherparams_test.go
+++ b/pkg/keystore/cipherparams_test.go
@@ -1,0 +1,120 @@
+package keystore_test
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/keystore"
+	"github.com/stretchr/testify/require"
+)
+
+// keystoreWithCrypto overrides individual crypto fields on an otherwise
+// well-formed v3 document so only the cipher-side fields are under test.
+func keystoreWithCrypto(t *testing.T, crypto map[string]interface{}) []byte {
+	t.Helper()
+	doc := map[string]interface{}{
+		"address": "41a614f803b6fd780986a42c78ec9c7f77e6ded13c",
+		"crypto":  crypto,
+		"id":      "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+		"version": 3,
+	}
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return b
+}
+
+func validCrypto() map[string]interface{} {
+	return map[string]interface{}{
+		"cipher":       "aes-128-ctr",
+		"ciphertext":   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		"cipherparams": map[string]interface{}{"iv": "0123456789abcdef0123456789abcdef"},
+		"kdf":          "scrypt",
+		"kdfparams": map[string]interface{}{
+			"dklen": 32, "n": 4096, "p": 1, "r": 8,
+			"salt": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+		"mac": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+}
+
+// Cipher-side fields are unauthenticated until the MAC is checked. Wrong IV
+// length previously panicked in cipher.NewCTR after a matching passphrase; huge
+// ciphertext/mac hex allocated before KDF. These must return errors, not panic.
+func TestDecryptKey_MalformedCipherFields(t *testing.T) {
+	tests := map[string]func() map[string]interface{}{
+		"iv too short": func() map[string]interface{} {
+			c := validCrypto()
+			c["cipherparams"] = map[string]interface{}{"iv": "0123456789abcdef"} // 8 bytes
+			return c
+		},
+		"iv too long": func() map[string]interface{} {
+			c := validCrypto()
+			c["cipherparams"] = map[string]interface{}{"iv": strings.Repeat("ab", 17)} // 17 bytes
+			return c
+		},
+		"iv hex beyond limit": func() map[string]interface{} {
+			c := validCrypto()
+			c["cipherparams"] = map[string]interface{}{"iv": strings.Repeat("ab", 33)} // > 16*2 hex
+			return c
+		},
+		"mac too short": func() map[string]interface{} {
+			c := validCrypto()
+			c["mac"] = "0123456789abcdef"
+			return c
+		},
+		"mac hex beyond limit": func() map[string]interface{} {
+			c := validCrypto()
+			c["mac"] = strings.Repeat("ab", 33) // > 32*2
+			return c
+		},
+		"ciphertext hex beyond limit": func() map[string]interface{} {
+			c := validCrypto()
+			c["ciphertext"] = strings.Repeat("ab", 1025) // > 1024 bytes
+			return c
+		},
+		"empty ciphertext": func() map[string]interface{} {
+			c := validCrypto()
+			c["ciphertext"] = ""
+			return c
+		},
+	}
+
+	for name, build := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := keystoreWithCrypto(t, build())
+			require.NotPanics(t, func() {
+				_, err := keystore.DecryptKey(doc, "passphrase")
+				require.Error(t, err)
+			})
+		})
+	}
+}
+
+// V1 CBC decrypt previously panicked in CryptBlocks when ciphertext was not a
+// multiple of the AES block size, even after a successful MAC check.
+func TestDecryptKey_V1CiphertextNotBlockAligned(t *testing.T) {
+	doc := map[string]interface{}{
+		"address": "41a614f803b6fd780986a42c78ec9c7f77e6ded13c",
+		"crypto": map[string]interface{}{
+			"cipher":       "aes-128-cbc",
+			"ciphertext":   "0123456789abcdef01", // 9 bytes — not a multiple of 16
+			"cipherparams": map[string]interface{}{"iv": "0123456789abcdef0123456789abcdef"},
+			"kdf":          "scrypt",
+			"kdfparams": map[string]interface{}{
+				"dklen": 32, "n": 4096, "p": 1, "r": 8,
+				"salt": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			},
+			"mac": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+		"id":      "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+		"version": "1",
+	}
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, err := keystore.DecryptKey(b, "passphrase")
+		require.Error(t, err)
+	})
+}

--- a/pkg/keystore/compat_test.go
+++ b/pkg/keystore/compat_test.go
@@ -1,0 +1,189 @@
+package keystore_test
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdsa"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/fbsobreira/gotron-sdk/pkg/address"
+	"github.com/fbsobreira/gotron-sdk/pkg/keystore"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/pbkdf2"
+	"golang.org/x/crypto/scrypt"
+)
+
+const compatPassphrase = "keystore compatibility test passphrase"
+
+// compatTestKey derives a throwaway signing key from a fixed label.
+//
+// It is derived rather than written as a hex literal on purpose: a 32-byte hex
+// string in a wallet SDK reads like a real private key, and nothing that looks
+// like one belongs in the repository. Deriving it keeps the expected address
+// stable across runs without storing a key.
+func compatTestKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	seed := sha256.Sum256([]byte("gotron-sdk keystore compatibility test — throwaway key, never funded"))
+	priv, err := ethcrypto.ToECDSA(seed[:])
+	require.NoError(t, err)
+	return priv
+}
+
+// buildV3Keystore produces a Web3 Secret Storage v3 document for the given KDF
+// parameters, following the same construction as EncryptDataV3 but without its
+// hardcoded r=8 / dklen=32. That is the point: the SDK only ever *writes* one
+// parameter set, so a round trip through EncryptKey/DecryptKey cannot show
+// whether files written by other tools — or by older versions — still open.
+func buildV3Keystore(t *testing.T, kdf string, params map[string]interface{}) []byte {
+	t.Helper()
+
+	priv := compatTestKey(t)
+	keyBytes := ethcrypto.FromECDSA(priv)
+
+	salt, err := hex.DecodeString(params["salt"].(string))
+	require.NoError(t, err)
+	dklen := params["dklen"].(int)
+
+	var derivedKey []byte
+	switch kdf {
+	case "scrypt":
+		derivedKey, err = scrypt.Key([]byte(compatPassphrase), salt,
+			params["n"].(int), params["r"].(int), params["p"].(int), dklen)
+		require.NoError(t, err)
+	case "pbkdf2":
+		derivedKey = pbkdf2.Key([]byte(compatPassphrase), salt,
+			params["c"].(int), dklen, sha256.New)
+	default:
+		t.Fatalf("unsupported kdf %q", kdf)
+	}
+
+	iv := make([]byte, aes.BlockSize)
+	block, err := aes.NewCipher(derivedKey[:16])
+	require.NoError(t, err)
+	cipherText := make([]byte, len(keyBytes))
+	cipher.NewCTR(block, iv).XORKeyStream(cipherText, keyBytes)
+
+	mac := ethcrypto.Keccak256(derivedKey[16:32], cipherText)
+
+	doc := map[string]interface{}{
+		"address": hex.EncodeToString(address.PubkeyToAddress(priv.PublicKey)),
+		"crypto": map[string]interface{}{
+			"cipher":       "aes-128-ctr",
+			"ciphertext":   hex.EncodeToString(cipherText),
+			"cipherparams": map[string]interface{}{"iv": hex.EncodeToString(iv)},
+			"kdf":          kdf,
+			"kdfparams":    params,
+			"mac":          hex.EncodeToString(mac),
+		},
+		"id":      "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+		"version": 3,
+	}
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return b
+}
+
+func compatSalt() string {
+	return "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+}
+
+// TestDecryptKey_ExistingKeystoreParams checks that keystores written with the
+// parameter sets found in the wild still open. The KDF validation added for W10
+// bounds n, r, p, c and dklen, and a bound that is too tight would lock users out
+// of their own wallets — which the existing round-trip tests cannot detect,
+// because they only ever encrypt with this SDK's own hardcoded parameters.
+func TestDecryptKey_ExistingKeystoreParams(t *testing.T) {
+	tests := map[string]struct {
+		kdf    string
+		params map[string]interface{}
+	}{
+		"geth light scrypt": {"scrypt", map[string]interface{}{
+			"n": 4096, "r": 8, "p": 6, "dklen": 32, "salt": compatSalt(),
+		}},
+		"metamask / myetherwallet scrypt": {"scrypt", map[string]interface{}{
+			"n": 8192, "r": 8, "p": 1, "dklen": 32, "salt": compatSalt(),
+		}},
+		"gotron-sdk light (LightScryptN/P)": {"scrypt", map[string]interface{}{
+			"n": 1 << 12, "r": 8, "p": 1, "dklen": 32, "salt": compatSalt(),
+		}},
+		"low n": {"scrypt", map[string]interface{}{
+			"n": 1024, "r": 8, "p": 1, "dklen": 32, "salt": compatSalt(),
+		}},
+		"r=1": {"scrypt", map[string]interface{}{
+			"n": 4096, "r": 1, "p": 1, "dklen": 32, "salt": compatSalt(),
+		}},
+		"r=16": {"scrypt", map[string]interface{}{
+			"n": 4096, "r": 16, "p": 1, "dklen": 32, "salt": compatSalt(),
+		}},
+		"p=8": {"scrypt", map[string]interface{}{
+			"n": 4096, "r": 8, "p": 8, "dklen": 32, "salt": compatSalt(),
+		}},
+		"pbkdf2 standard": {"pbkdf2", map[string]interface{}{
+			"c": 262144, "dklen": 32, "prf": "hmac-sha256", "salt": compatSalt(),
+		}},
+		"pbkdf2 low iterations": {"pbkdf2", map[string]interface{}{
+			"c": 10240, "dklen": 32, "prf": "hmac-sha256", "salt": compatSalt(),
+		}},
+		"dklen above 32": {"scrypt", map[string]interface{}{
+			"n": 4096, "r": 8, "p": 1, "dklen": 64, "salt": compatSalt(),
+		}},
+	}
+
+	priv := compatTestKey(t)
+	wantAddr := address.PubkeyToAddress(priv.PublicKey)
+	wantKey := hex.EncodeToString(ethcrypto.FromECDSA(priv))
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := buildV3Keystore(t, tt.kdf, tt.params)
+
+			key, err := keystore.DecryptKey(doc, compatPassphrase)
+			require.NoError(t, err, "a keystore with these parameters must still decrypt")
+			require.Equal(t, wantAddr.String(), key.Address.String())
+			require.Equal(t, wantKey, hex.EncodeToString(ethcrypto.FromECDSA(key.PrivateKey)))
+		})
+	}
+}
+
+// The geth default is 256 MiB of scrypt working set, so it is slow enough to skip
+// under -short. It is the parameter set gotron-sdk itself writes via StandardScryptN.
+func TestDecryptKey_StandardScryptParams(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scrypt N=1<<18 needs 256 MiB and about a second")
+	}
+	doc := buildV3Keystore(t, "scrypt", map[string]interface{}{
+		"n": keystore.StandardScryptN, "r": 8, "p": keystore.StandardScryptP,
+		"dklen": 32, "salt": compatSalt(),
+	})
+	key, err := keystore.DecryptKey(doc, compatPassphrase)
+	require.NoError(t, err)
+	require.Equal(t,
+		hex.EncodeToString(ethcrypto.FromECDSA(compatTestKey(t))),
+		hex.EncodeToString(ethcrypto.FromECDSA(key.PrivateKey)))
+}
+
+// The wrong passphrase must still be reported as such, not as a parameter error.
+func TestDecryptKey_WrongPassphraseStillReported(t *testing.T) {
+	doc := buildV3Keystore(t, "scrypt", map[string]interface{}{
+		"n": 4096, "r": 8, "p": 1, "dklen": 32, "salt": compatSalt(),
+	})
+	_, err := keystore.DecryptKey(doc, "not the passphrase")
+	require.ErrorIs(t, err, keystore.ErrDecrypt)
+}
+
+// The one deliberate incompatibility: dklen below 32 is now rejected. The decrypt
+// paths read derivedKey[:16] and derivedKey[16:32], so such a file was never
+// usable — it only avoided a panic because the KDFs return spare capacity, and it
+// is invalid under the v3 spec, which fixes dklen at 32.
+func TestDecryptKey_ShortDKLenIsRejected(t *testing.T) {
+	doc := buildV3Keystore(t, "scrypt", map[string]interface{}{
+		"n": 4096, "r": 8, "p": 1, "dklen": 16, "salt": compatSalt(),
+	})
+	_, err := keystore.DecryptKey(doc, compatPassphrase)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "dklen")
+}

--- a/pkg/keystore/crypto.go
+++ b/pkg/keystore/crypto.go
@@ -3,10 +3,14 @@ package keystore
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"fmt"
 )
 
 func aesCTRXOR(key, inText, iv []byte) ([]byte, error) {
 	// AES-128 is selected due to size of encryptKey.
+	if len(iv) != aes.BlockSize {
+		return nil, fmt.Errorf("aes-128-ctr: iv must be %d bytes, got %d", aes.BlockSize, len(iv))
+	}
 	aesBlock, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
@@ -18,6 +22,14 @@ func aesCTRXOR(key, inText, iv []byte) ([]byte, error) {
 }
 
 func aesCBCDecrypt(key, cipherText, iv []byte) ([]byte, error) {
+	if len(iv) != aes.BlockSize {
+		return nil, fmt.Errorf("aes-128-cbc: iv must be %d bytes, got %d", aes.BlockSize, len(iv))
+	}
+	// CryptBlocks panics when the input length is not a multiple of the block size.
+	if len(cipherText) == 0 || len(cipherText)%aes.BlockSize != 0 {
+		return nil, fmt.Errorf("aes-128-cbc: ciphertext length must be a positive multiple of %d, got %d",
+			aes.BlockSize, len(cipherText))
+	}
 	aesBlock, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err

--- a/pkg/keystore/crypto_internal_test.go
+++ b/pkg/keystore/crypto_internal_test.go
@@ -205,6 +205,23 @@ func TestAesCBCDecrypt(t *testing.T) {
 		_, err := aesCBCDecrypt([]byte("short"), make([]byte, 16), make([]byte, 16))
 		assert.Error(t, err)
 	})
+
+	t.Run("wrong IV length returns error", func(t *testing.T) {
+		_, err := aesCBCDecrypt(make([]byte, 16), make([]byte, 16), make([]byte, 8))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "iv must be")
+	})
+
+	t.Run("ciphertext not block aligned returns error", func(t *testing.T) {
+		_, err := aesCBCDecrypt(make([]byte, 16), make([]byte, 15), make([]byte, 16))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "multiple of")
+	})
+
+	t.Run("empty ciphertext returns error", func(t *testing.T) {
+		_, err := aesCBCDecrypt(make([]byte, 16), nil, make([]byte, 16))
+		require.Error(t, err)
+	})
 }
 
 // ---------- aesCTRXOR ----------
@@ -290,6 +307,12 @@ func TestAesCTRXOR(t *testing.T) {
 	t.Run("invalid key size returns error", func(t *testing.T) {
 		_, err := aesCTRXOR([]byte("bad"), []byte("data"), make([]byte, 16))
 		assert.Error(t, err)
+	})
+
+	t.Run("wrong IV length returns error", func(t *testing.T) {
+		_, err := aesCTRXOR(make([]byte, 16), []byte("data"), make([]byte, 8))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "iv must be")
 	})
 }
 

--- a/pkg/keystore/kdf_internal_test.go
+++ b/pkg/keystore/kdf_internal_test.go
@@ -1,0 +1,31 @@
+package keystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestKdfInt_IntAndInt64(t *testing.T) {
+	params := map[string]interface{}{
+		"n":  int(4096),
+		"r":  int64(8),
+		"p":  float64(1),
+		"lo": 0,
+	}
+	n, err := kdfInt(params, "n", 2, maxScryptN)
+	require.NoError(t, err)
+	require.Equal(t, 4096, n)
+
+	r, err := kdfInt(params, "r", 1, maxScryptR)
+	require.NoError(t, err)
+	require.Equal(t, 8, r)
+
+	p, err := kdfInt(params, "p", 1, maxScryptP)
+	require.NoError(t, err)
+	require.Equal(t, 1, p)
+
+	_, err = kdfInt(params, "lo", 1, 10)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "must be in")
+}

--- a/pkg/keystore/kdfparams_test.go
+++ b/pkg/keystore/kdfparams_test.go
@@ -1,0 +1,129 @@
+package keystore_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/fbsobreira/gotron-sdk/pkg/keystore"
+	"github.com/stretchr/testify/require"
+)
+
+// keystoreWithKDFParams builds a v3 keystore whose kdfparams are exactly the
+// given map. Everything else is well formed, so the only thing under test is how
+// getKDFKey handles the parameters — which it consumes *before* the MAC is
+// verified, making them unauthenticated attacker-controlled input.
+func keystoreWithKDFParams(t *testing.T, kdf string, params map[string]interface{}) []byte {
+	t.Helper()
+	doc := map[string]interface{}{
+		"address": "41a614f803b6fd780986a42c78ec9c7f77e6ded13c",
+		"crypto": map[string]interface{}{
+			"cipher":       "aes-128-ctr",
+			"ciphertext":   "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			"cipherparams": map[string]interface{}{"iv": "0123456789abcdef0123456789abcdef"},
+			"kdf":          kdf,
+			"kdfparams":    params,
+			"mac":          "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		},
+		"id":      "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+		"version": 3,
+	}
+	b, err := json.Marshal(doc)
+	require.NoError(t, err)
+	return b
+}
+
+func TestDecryptKey_MalformedKDFParams(t *testing.T) {
+	validScrypt := func() map[string]interface{} {
+		return map[string]interface{}{
+			"dklen": 32, "n": 4096, "p": 1, "r": 8,
+			"salt": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		}
+	}
+
+	tests := map[string]struct {
+		kdf    string
+		params map[string]interface{}
+	}{
+		// Each of these previously hit an unchecked type assertion and panicked:
+		// a missing key yields nil, and nil.(string) / nil.(float64) both panic.
+		"missing salt": {"scrypt", map[string]interface{}{"dklen": 32, "n": 4096, "p": 1, "r": 8}},
+		"salt not a string": {"scrypt", map[string]interface{}{
+			"dklen": 32, "n": 4096, "p": 1, "r": 8, "salt": 12345,
+		}},
+		"salt not hex": {"scrypt", map[string]interface{}{
+			"dklen": 32, "n": 4096, "p": 1, "r": 8, "salt": "nothex",
+		}},
+		"missing n":            {"scrypt", withoutKey(validScrypt(), "n")},
+		"missing r":            {"scrypt", withoutKey(validScrypt(), "r")},
+		"missing p":            {"scrypt", withoutKey(validScrypt(), "p")},
+		"missing dklen":        {"scrypt", withoutKey(validScrypt(), "dklen")},
+		"n not a number":       {"scrypt", withKey(validScrypt(), "n", "lots")},
+		"n not a whole number": {"scrypt", withKey(validScrypt(), "n", 4096.5)},
+		"pbkdf2 missing prf": {"pbkdf2", map[string]interface{}{
+			"dklen": 32, "c": 262144,
+			"salt": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		}},
+		"pbkdf2 prf not a string": {"pbkdf2", map[string]interface{}{
+			"dklen": 32, "c": 262144, "prf": 7,
+			"salt": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		}},
+
+		// Unbounded cost. These are rejected on the parameters alone, before any
+		// derivation runs, so the test finishes immediately instead of trying to
+		// allocate the requested working set.
+		"n beyond limit":     {"scrypt", withKey(validScrypt(), "n", 1<<40)},
+		"r beyond limit":     {"scrypt", withKey(validScrypt(), "r", 1<<20)},
+		"p beyond limit":     {"scrypt", withKey(validScrypt(), "p", 1<<20)},
+		"dklen beyond limit": {"scrypt", withKey(validScrypt(), "dklen", 1<<30)},
+		"pbkdf2 c beyond limit": {"pbkdf2", map[string]interface{}{
+			"dklen": 32, "c": 1 << 40, "prf": "hmac-sha256",
+			"salt": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		}},
+		// Within the individual limits, but 128*N*r would be ~34 GiB.
+		"scrypt memory beyond limit": {"scrypt", withKey(withKey(validScrypt(), "n", 1<<22), "r", 64)},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := keystoreWithKDFParams(t, tt.kdf, tt.params)
+
+			// The worker only collects a result. testify's require calls
+			// t.FailNow, which must run on the test goroutine — calling it from
+			// here would Goexit the wrong stack and could hang or misreport
+			// instead of failing cleanly. So all assertions happen below.
+			type outcome struct {
+				err      error
+				panicked any
+			}
+			results := make(chan outcome, 1)
+			go func() {
+				defer func() {
+					if r := recover(); r != nil {
+						results <- outcome{panicked: r}
+					}
+				}()
+				_, err := keystore.DecryptKey(doc, "passphrase")
+				results <- outcome{err: err}
+			}()
+
+			select {
+			case got := <-results:
+				require.Nil(t, got.panicked, "DecryptKey panicked instead of returning an error")
+				require.Error(t, got.err)
+			case <-time.After(20 * time.Second):
+				t.Fatal("DecryptKey did not reject the parameters promptly — cost is still unbounded")
+			}
+		})
+	}
+}
+
+func withoutKey(m map[string]interface{}, key string) map[string]interface{} {
+	delete(m, key)
+	return m
+}
+
+func withKey(m map[string]interface{}, key string, value interface{}) map[string]interface{} {
+	m[key] = value
+	return m
+}

--- a/pkg/keystore/kdfparams_test.go
+++ b/pkg/keystore/kdfparams_test.go
@@ -2,6 +2,7 @@ package keystore_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,6 +91,8 @@ func TestDecryptKey_MalformedKDFParams(t *testing.T) {
 		}},
 		// Within the individual limits, but 128*N*r would be ~34 GiB.
 		"scrypt memory beyond limit": {"scrypt", withKey(withKey(validScrypt(), "n", 1<<22), "r", 64)},
+		// Salt amplifies pre-MAC KDF cost and allocates on hex decode.
+		"salt beyond limit": {"scrypt", withKey(validScrypt(), "salt", strings.Repeat("aa", 65))},
 	}
 
 	for name, tt := range tests {

--- a/pkg/keystore/kdfparams_test.go
+++ b/pkg/keystore/kdfparams_test.go
@@ -76,6 +76,14 @@ func TestDecryptKey_MalformedKDFParams(t *testing.T) {
 		"r beyond limit":     {"scrypt", withKey(validScrypt(), "r", 1<<20)},
 		"p beyond limit":     {"scrypt", withKey(validScrypt(), "p", 1<<20)},
 		"dklen beyond limit": {"scrypt", withKey(validScrypt(), "dklen", 1<<30)},
+		// The decrypt paths read derivedKey[16:32]; anything below 32 is unusable
+		// and only avoids a panic because the KDFs return spare capacity.
+		"dklen below 32":      {"scrypt", withKey(validScrypt(), "dklen", 1)},
+		"dklen just below 32": {"scrypt", withKey(validScrypt(), "dklen", 31)},
+		"pbkdf2 dklen below 32": {"pbkdf2", map[string]interface{}{
+			"dklen": 16, "c": 262144, "prf": "hmac-sha256",
+			"salt": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+		}},
 		"pbkdf2 c beyond limit": {"pbkdf2", map[string]interface{}{
 			"dklen": 32, "c": 1 << 40, "prf": "hmac-sha256",
 			"salt": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",

--- a/pkg/keystore/key.go
+++ b/pkg/keystore/key.go
@@ -17,7 +17,6 @@
 package keystore
 
 import (
-	"bytes"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
@@ -25,7 +24,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -135,27 +133,6 @@ func newKeyFromECDSA(privateKeyECDSA *ecdsa.PrivateKey) *Key {
 		ID:         id,
 		Address:    address.PubkeyToAddress(privateKeyECDSA.PublicKey),
 		PrivateKey: privateKeyECDSA,
-	}
-	return key
-}
-
-// NewKeyForDirectICAP generates a key whose address fits into < 155 bits so it can fit
-// into the Direct ICAP spec. for simplicity and easier compatibility with other libs, we
-// retry until the first byte is 0.
-func NewKeyForDirectICAP(rand io.Reader) *Key {
-	randBytes := make([]byte, 64)
-	_, err := rand.Read(randBytes)
-	if err != nil {
-		panic("key generation: could not read from random source: " + err.Error())
-	}
-	reader := bytes.NewReader(randBytes)
-	privateKeyECDSA, err := ecdsa.GenerateKey(crypto.S256(), reader)
-	if err != nil {
-		panic("key generation: ecdsa.GenerateKey failed: " + err.Error())
-	}
-	key := newKeyFromECDSA(privateKeyECDSA)
-	if !strings.HasPrefix(key.Address.Hex(), "0x00") {
-		return NewKeyForDirectICAP(rand)
 	}
 	return key
 }

--- a/pkg/keystore/key_test.go
+++ b/pkg/keystore/key_test.go
@@ -127,12 +127,6 @@ func TestKeyJSON(t *testing.T) {
 	})
 }
 
-// Note: NewKeyForDirectICAP is not tested here because it uses recursive retries
-// until the generated address fits into < 155 bits, which can overflow the stack
-// with the standard rand.Reader (each call reads a fixed 64-byte buffer and derives
-// a deterministic reader, so the chance of hitting a valid address per attempt is
-// very low). The function is exercised indirectly via integration if needed.
-
 // ---------- storeNewKey ----------
 
 func TestStoreNewKey(t *testing.T) {

--- a/pkg/keystore/key_test.go
+++ b/pkg/keystore/key_test.go
@@ -231,6 +231,25 @@ func TestEncryptDataV3(t *testing.T) {
 		_, err = DecryptDataV3(cj, "wrong-password")
 		assert.Error(t, err)
 	})
+
+	// Encrypt and Decrypt share maxCiphertextLen so oversized payloads cannot
+	// encrypt into a CryptoJSON this package refuses to decrypt.
+	t.Run("plaintext at ciphertext limit encrypts and decrypts", func(t *testing.T) {
+		data := make([]byte, 1024)
+		auth := []byte("limit-pass")
+		cj, err := EncryptDataV3(data, auth, LightScryptN, LightScryptP)
+		require.NoError(t, err)
+		got, err := DecryptDataV3(cj, string(auth))
+		require.NoError(t, err)
+		assert.Equal(t, data, got)
+	})
+
+	t.Run("plaintext over ciphertext limit is rejected before KDF", func(t *testing.T) {
+		data := make([]byte, 1025)
+		_, err := EncryptDataV3(data, []byte("limit-pass"), LightScryptN, LightScryptP)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds limit")
+	})
 }
 
 // ---------- writeTemporaryKeyFile ----------

--- a/pkg/keystore/passphrase.go
+++ b/pkg/keystore/passphrase.go
@@ -337,6 +337,11 @@ const (
 	// capacity. Requiring the V3 spec's 32 removes that reliance.
 	minDerivedKeyLen = 32
 	maxDerivedKeyLen = 1024
+	// Salt is unauthenticated and feeds both scrypt and pbkdf2 before the MAC is
+	// checked. A multi-megabyte salt hex-decodes into a large allocation and
+	// amplifies PBKDF2/scrypt setup cost. Common wallets use 16–32 bytes; 64
+	// leaves headroom without allowing unbounded input.
+	maxSaltLen = 64
 )
 
 // kdfString reads a string KDF parameter with a checked assertion. The params map
@@ -393,9 +398,16 @@ func getKDFKey(cryptoJSON CryptoJSON, auth string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Bound before decode so a multi-megabyte hex string is not materialised.
+	if len(saltHex) > maxSaltLen*2 {
+		return nil, fmt.Errorf("kdf params: salt hex length %d exceeds limit %d", len(saltHex), maxSaltLen*2)
+	}
 	salt, err := hex.DecodeString(saltHex)
 	if err != nil {
 		return nil, err
+	}
+	if len(salt) > maxSaltLen {
+		return nil, fmt.Errorf("kdf params: salt length %d exceeds limit %d", len(salt), maxSaltLen)
 	}
 	dkLen, err := kdfInt(cryptoJSON.KDFParams, "dklen", minDerivedKeyLen, maxDerivedKeyLen)
 	if err != nil {

--- a/pkg/keystore/passphrase.go
+++ b/pkg/keystore/passphrase.go
@@ -233,22 +233,12 @@ func DecryptKey(keyjson []byte, auth string) (*Key, error) {
 	}, nil
 }
 
-// DecryptDataV3 ...
+// DecryptDataV3 decrypts Web3 Secret Storage v3 crypto fields.
 func DecryptDataV3(cj CryptoJSON, auth string) ([]byte, error) {
 	if cj.Cipher != "aes-128-ctr" {
 		return nil, fmt.Errorf("Cipher not supported: %v", cj.Cipher)
 	}
-	mac, err := hex.DecodeString(cj.MAC)
-	if err != nil {
-		return nil, err
-	}
-
-	iv, err := hex.DecodeString(cj.CipherParams.IV)
-	if err != nil {
-		return nil, err
-	}
-
-	cipherText, err := hex.DecodeString(cj.CipherText)
+	mac, iv, cipherText, err := decodeCipherFields(cj.MAC, cj.CipherParams.IV, cj.CipherText, false)
 	if err != nil {
 		return nil, err
 	}
@@ -270,6 +260,53 @@ func DecryptDataV3(cj CryptoJSON, auth string) ([]byte, error) {
 	return plainText, err
 }
 
+// decodeCipherFields bounds and decodes MAC, IV and ciphertext hex before any KDF
+// work. CTR (v3) accepts any ciphertext length up to the ceiling; CBC (v1) also
+// requires a positive multiple of the AES block size so CryptBlocks cannot panic.
+func decodeCipherFields(macHex, ivHex, cipherHex string, cbc bool) (mac, iv, cipherText []byte, err error) {
+	if len(macHex) > macLen*2 {
+		return nil, nil, nil, fmt.Errorf("crypto: mac hex length %d exceeds limit %d", len(macHex), macLen*2)
+	}
+	if len(ivHex) > aesIVLen*2 {
+		return nil, nil, nil, fmt.Errorf("crypto: iv hex length %d exceeds limit %d", len(ivHex), aesIVLen*2)
+	}
+	if len(cipherHex) > maxCiphertextLen*2 {
+		return nil, nil, nil, fmt.Errorf("crypto: ciphertext hex length %d exceeds limit %d", len(cipherHex), maxCiphertextLen*2)
+	}
+
+	mac, err = hex.DecodeString(macHex)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(mac) != macLen {
+		return nil, nil, nil, fmt.Errorf("crypto: mac must be %d bytes, got %d", macLen, len(mac))
+	}
+
+	iv, err = hex.DecodeString(ivHex)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(iv) != aesIVLen {
+		return nil, nil, nil, fmt.Errorf("crypto: iv must be %d bytes, got %d", aesIVLen, len(iv))
+	}
+
+	cipherText, err = hex.DecodeString(cipherHex)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if len(cipherText) == 0 {
+		return nil, nil, nil, fmt.Errorf("crypto: empty ciphertext")
+	}
+	if len(cipherText) > maxCiphertextLen {
+		return nil, nil, nil, fmt.Errorf("crypto: ciphertext length %d exceeds limit %d", len(cipherText), maxCiphertextLen)
+	}
+	if cbc && len(cipherText)%aes.BlockSize != 0 {
+		return nil, nil, nil, fmt.Errorf("crypto: cbc ciphertext length must be a multiple of %d, got %d",
+			aes.BlockSize, len(cipherText))
+	}
+	return mac, iv, cipherText, nil
+}
+
 func decryptKeyV3(keyProtected *encryptedKeyJSONV3, auth string) (keyBytes []byte, keyID []byte, err error) {
 	if keyProtected.Version != version {
 		return nil, nil, fmt.Errorf("Version not supported: %v", keyProtected.Version)
@@ -284,17 +321,12 @@ func decryptKeyV3(keyProtected *encryptedKeyJSONV3, auth string) (keyBytes []byt
 
 func decryptKeyV1(keyProtected *encryptedKeyJSONV1, auth string) (keyBytes []byte, keyID []byte, err error) {
 	keyID = uuid.Parse(keyProtected.ID)
-	mac, err := hex.DecodeString(keyProtected.Crypto.MAC)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	iv, err := hex.DecodeString(keyProtected.Crypto.CipherParams.IV)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	cipherText, err := hex.DecodeString(keyProtected.Crypto.CipherText)
+	mac, iv, cipherText, err := decodeCipherFields(
+		keyProtected.Crypto.MAC,
+		keyProtected.Crypto.CipherParams.IV,
+		keyProtected.Crypto.CipherText,
+		true,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -342,6 +374,14 @@ const (
 	// amplifies PBKDF2/scrypt setup cost. Common wallets use 16–32 bytes; 64
 	// leaves headroom without allowing unbounded input.
 	maxSaltLen = 64
+	// Cipher-side fields are also unauthenticated until the MAC is checked.
+	// Keccak256 MACs are 32 bytes; AES-128 IVs are 16. Ciphertext is only a
+	// private key (32 bytes) for EncryptKey, but DecryptDataV3 is public — keep
+	// a modest ceiling so a multi-megabyte field cannot force decode+KDF+Keccak
+	// before rejection.
+	macLen           = 32
+	aesIVLen         = 16
+	maxCiphertextLen = 1024
 )
 
 // kdfString reads a string KDF parameter with a checked assertion. The params map

--- a/pkg/keystore/passphrase.go
+++ b/pkg/keystore/passphrase.go
@@ -328,8 +328,14 @@ const (
 	maxScryptP = 16
 	// scrypt's working set is 128 * N * r bytes. StandardScryptN with r=8 needs
 	// 256 MiB, so 1 GiB leaves generous headroom while still bounding the cost.
-	maxScryptMemory  = 1 << 30
-	maxPBKDF2Count   = 1 << 24
+	maxScryptMemory = 1 << 30
+	maxPBKDF2Count  = 1 << 24
+	// The decrypt paths read derivedKey[:16] for the AES key and derivedKey[16:32]
+	// for the MAC, so anything shorter than 32 is unusable. It does not panic today
+	// only because scrypt.Key and pbkdf2.Key happen to return a slice with cap 32
+	// even when dklen is 1, so the expression reads past len into the spare
+	// capacity. Requiring the V3 spec's 32 removes that reliance.
+	minDerivedKeyLen = 32
 	maxDerivedKeyLen = 1024
 )
 
@@ -391,7 +397,7 @@ func getKDFKey(cryptoJSON CryptoJSON, auth string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	dkLen, err := kdfInt(cryptoJSON.KDFParams, "dklen", 1, maxDerivedKeyLen)
+	dkLen, err := kdfInt(cryptoJSON.KDFParams, "dklen", minDerivedKeyLen, maxDerivedKeyLen)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/keystore/passphrase.go
+++ b/pkg/keystore/passphrase.go
@@ -316,23 +316,113 @@ func decryptKeyV1(keyProtected *encryptedKeyJSONV1, auth string) (keyBytes []byt
 	return plainText, keyID, err
 }
 
+// KDF parameter limits.
+//
+// getKDFKey consumes these values *before* the MAC is verified, so they are
+// unauthenticated attacker-controlled input. Without upper bounds a crafted
+// keystore file forces an arbitrarily expensive derivation — memory and CPU
+// exhaustion — before anything establishes that the file is even genuine.
+const (
+	maxScryptN = 1 << 22
+	maxScryptR = 64
+	maxScryptP = 16
+	// scrypt's working set is 128 * N * r bytes. StandardScryptN with r=8 needs
+	// 256 MiB, so 1 GiB leaves generous headroom while still bounding the cost.
+	maxScryptMemory  = 1 << 30
+	maxPBKDF2Count   = 1 << 24
+	maxDerivedKeyLen = 1024
+)
+
+// kdfString reads a string KDF parameter with a checked assertion. The params map
+// is decoded from caller-supplied JSON, so a missing key yields nil and an
+// unchecked assertion would panic.
+func kdfString(params map[string]interface{}, key string) (string, error) {
+	v, ok := params[key]
+	if !ok {
+		return "", fmt.Errorf("kdf params: missing %q", key)
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("kdf params: %q must be a string, got %T", key, v)
+	}
+	return s, nil
+}
+
+// kdfInt reads a numeric KDF parameter and enforces [minv, maxv]. It replaces
+// ensureInt, which asserted straight to float64 with no comma-ok and panicked on
+// a missing key or any other type.
+func kdfInt(params map[string]interface{}, key string, minv, maxv int) (int, error) {
+	v, ok := params[key]
+	if !ok {
+		return 0, fmt.Errorf("kdf params: missing %q", key)
+	}
+	var n int
+	switch t := v.(type) {
+	case int:
+		n = t
+	case int64:
+		n = int(t)
+	case float64:
+		// encoding/json decodes every JSON number into float64. Range-check before
+		// converting: converting an out-of-range float to int is undefined in Go.
+		if t < float64(minv) || t > float64(maxv) {
+			return 0, fmt.Errorf("kdf params: %q must be in [%d, %d], got %v", key, minv, maxv, t)
+		}
+		n = int(t)
+		if float64(n) != t {
+			return 0, fmt.Errorf("kdf params: %q must be a whole number, got %v", key, t)
+		}
+	default:
+		return 0, fmt.Errorf("kdf params: %q must be a number, got %T", key, v)
+	}
+	if n < minv || n > maxv {
+		return 0, fmt.Errorf("kdf params: %q must be in [%d, %d], got %d", key, minv, maxv, n)
+	}
+	return n, nil
+}
+
 func getKDFKey(cryptoJSON CryptoJSON, auth string) ([]byte, error) {
 	authArray := []byte(auth)
-	salt, err := hex.DecodeString(cryptoJSON.KDFParams["salt"].(string))
+	saltHex, err := kdfString(cryptoJSON.KDFParams, "salt")
 	if err != nil {
 		return nil, err
 	}
-	dkLen := ensureInt(cryptoJSON.KDFParams["dklen"])
+	salt, err := hex.DecodeString(saltHex)
+	if err != nil {
+		return nil, err
+	}
+	dkLen, err := kdfInt(cryptoJSON.KDFParams, "dklen", 1, maxDerivedKeyLen)
+	if err != nil {
+		return nil, err
+	}
 
 	switch cryptoJSON.KDF {
 	case keyHeaderKDF:
-		n := ensureInt(cryptoJSON.KDFParams["n"])
-		r := ensureInt(cryptoJSON.KDFParams["r"])
-		p := ensureInt(cryptoJSON.KDFParams["p"])
+		n, err := kdfInt(cryptoJSON.KDFParams, "n", 2, maxScryptN)
+		if err != nil {
+			return nil, err
+		}
+		r, err := kdfInt(cryptoJSON.KDFParams, "r", 1, maxScryptR)
+		if err != nil {
+			return nil, err
+		}
+		p, err := kdfInt(cryptoJSON.KDFParams, "p", 1, maxScryptP)
+		if err != nil {
+			return nil, err
+		}
+		if mem := 128 * int64(n) * int64(r); mem > maxScryptMemory {
+			return nil, fmt.Errorf("kdf params: scrypt would allocate %d bytes, limit is %d", mem, maxScryptMemory)
+		}
 		return scrypt.Key(authArray, salt, n, r, p, dkLen)
 	case "pbkdf2":
-		c := ensureInt(cryptoJSON.KDFParams["c"])
-		prf := cryptoJSON.KDFParams["prf"].(string)
+		c, err := kdfInt(cryptoJSON.KDFParams, "c", 1, maxPBKDF2Count)
+		if err != nil {
+			return nil, err
+		}
+		prf, err := kdfString(cryptoJSON.KDFParams, "prf")
+		if err != nil {
+			return nil, err
+		}
 		if prf != "hmac-sha256" {
 			return nil, fmt.Errorf("Unsupported PBKDF2 PRF: %s", prf)
 		}
@@ -341,15 +431,4 @@ func getKDFKey(cryptoJSON CryptoJSON, auth string) ([]byte, error) {
 	default:
 		return nil, fmt.Errorf("Unsupported KDF: %s", cryptoJSON.KDF)
 	}
-}
-
-// TODO: can we do without this when unmarshalling dynamic JSON?
-// why do integers in KDF params end up as float64 and not int after
-// unmarshal?
-func ensureInt(x interface{}) int {
-	res, ok := x.(int)
-	if !ok {
-		res = int(x.(float64))
-	}
-	return res
 }

--- a/pkg/keystore/passphrase.go
+++ b/pkg/keystore/passphrase.go
@@ -135,7 +135,14 @@ func (ks keyStorePassphrase) JoinPath(filename string) string {
 }
 
 // EncryptDataV3 encrypts the data given as 'data' with the password 'auth'.
+//
+// Plaintext longer than maxCiphertextLen (1024 bytes) is rejected so the
+// ciphertext stays within the same bound DecryptDataV3 enforces. EncryptKey
+// only encrypts a 32-byte private key and is unaffected.
 func EncryptDataV3(data, auth []byte, scryptN, scryptP int) (CryptoJSON, error) {
+	if len(data) > maxCiphertextLen {
+		return CryptoJSON{}, fmt.Errorf("crypto: plaintext length %d exceeds limit %d", len(data), maxCiphertextLen)
+	}
 
 	salt := make([]byte, 32)
 	if _, err := io.ReadFull(rand.Reader, salt); err != nil {


### PR DESCRIPTION
Wave 1 of the repository review: twelve findings that share one defect class — data from the node,
from a keystore file, or from a caller reaching an index, a type assertion, or a pointer dereference
with no check.

## `pkg/client` — node responses

| | |
|---|---|
| **C8** | `ParseTRC20StringProperty` took the ABI string length from contract return data and evaluated `2*int(l)`, which overflows to a negative value, passed the bounds check, then panicked on the slice. |
| **W11** | Four TRC20 queries indexed `GetConstantResult()[0]` unguarded; a node may report success with no entries. |
| **W12** | `TRC20Send`/`Approve`/`TransferFrom` encoded amounts with `LeftPadBytes`. |
| **W27** | `DeployContractCtx` assigned through `tx.Transaction.RawData` without checking the result code. |
| **W28** | `UpdateAccountPermissionCtx` made eight unchecked assertions on caller-supplied maps. |
| **W43** | `GetTransactionInfoByIDCtx` dereferenced a possibly-nil response. |
| **W44** | `WithdrawExpireUnfreeze`, `DelegateResource`, `UnDelegateResource` skipped the result-code check every sibling performs. |

### C8 had two failure modes, not one

Verified by running the original bounds check against each input:

| Declared length | Old behaviour |
|---|---|
| 2^62 | **panic** — `slice bounds [:9223372036854775936]` |
| 2^63 | silent `""` — `2*l` wraps to exactly 0 |
| max uint64 | **panic** |
| 2^254 | silent `""` — `Uint64` truncates to the low bits |
| max uint256 | **panic** |

A hostile `name()` could therefore return an empty token name **with a nil error**, not only crash. Now
`IsUint64` catches the truncation and the bound is expressed as a division, so no multiplication exists
to overflow.

### W12 encoding is unchanged for valid amounts

All three sites now use `trc20enc.PadUint256`. Confirmed **byte-identical** to `LeftPadBytes` across
`0`, `1`, `1e6`, max uint64, 2^255−1 and max uint256 — zero mismatches, so calldata for any amount that
worked before is untouched. What changes is that `nil` (panicked), negative (silently became a real
positive transfer, because `big.Int.Bytes` returns the absolute value) and >256-bit values (appended
whole, because `LeftPadBytes` does not truncate) are now rejected.

## Five further sites of the same class

Found while reviewing the above. `triggerConstantContract`, `triggerContract`, `DeployContract` and
their callers in `contracts.go`, plus `TRC20CallCtx`, all read `tx.Result.Code` **directly** rather
than through the nil-safe accessor, so a response with no `Result` panicked. `TRC20CallCtx` gates all
four W11 queries — the constant-result indexing was guarded while a nil-`Result` panic sat upstream on
the same path. `triggerContract` also assigned through `tx.Transaction.RawData` with no nil check, the
same shape as W27.

## `pkg/common/numeric`

- **W37** — unanchored regex, so `"1e5x"` matched, `Atoi("5x")` failed silently, and the function
  returned `1` with a **nil error**. Anchored; both errors propagate.
- **W38** — a nil `*big.Int` from `SetString` reached `Mul` and panicked. It also accepted a sign
  (because `big.Int.SetString` does), yielding a *negative* `Dec` out of a hex parser.

## `pkg/keystore`

- **W10** — `getKDFKey` asserted `salt`/`prf` to string and every numeric parameter to `float64` with no
  comma-ok, and passed `n`, `r`, `p` to scrypt with **no upper bound** — all *before* the MAC is
  verified. A crafted file could panic the process or force an unbounded derivation. Bounds leave room
  for `StandardScryptN` (256 MiB working set) and pbkdf2 defaults.
- **W26** — `NewKeyForDirectICAP` retried until an address began with `0x00`, which a TRON address never
  does, so every call recursed until the stack overflowed. Removed; ICAP has no meaning on TRON.

## Testing

**W66** adds the negative-case coverage whose absence let W37 and W38 survive.

Tests assert both that input is rejected **and** that nothing panics. Branches a real gRPC round trip
cannot produce — a nil `TransactionInfo`, a nil `Result` — are reached by stubbing the exported `Client`
field, which is also how an SDK consumer can produce them. (`grpc-go` materialises a `(nil, nil)` server
return into an empty message, so a mock server cannot reach those guards; coverage confirmed the branch
was dead before this change.)

Every touched function keeps its pre-existing happy-path test. Coverage: `pkg/client` 83.5 → 84.7%,
`numeric` 91.7 → 92.9%, `keystore` 84.0 → 86.1%.

`make lint` (0 issues) · `make test` (20/20 packages) · `go test ./cmd/...` · `make` — all clean.

## Not included

**W42** (nil `g.Client` before `Start`) is a mechanical sweep of **80 call sites across 13 files** and
does not belong in the same diff as these targeted guards. It gets its own PR.

## ⚠️ Behaviour change for release notes

**W27 and W44 change observable behaviour.** Callers that previously received a `TransactionExtention`
for a request the node *rejected* now receive an error. That is the fix — the failure previously
surfaced only after signing and broadcast, or not at all — but it is breaking for anyone who was
ignoring the result code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of node-rejected transactions across account, asset, bank, contract, exchange, proposal, resource, transfer, and witness operations.
  * Prevented crashes on empty, nil, or malformed responses, permissions, transaction lookups, and TRC20 calls.
  * Hardened numeric parsing and TRC20 decoding against overflow, underflow, and malformed input.
  * Strengthened keystore decryption by validating cipher, KDF, and encryption parameters.
* **Breaking Changes**
  * Removed the Direct ICAP key-generation helper.
* **Tests**
  * Added extensive regression coverage for malformed inputs and rejected responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->